### PR TITLE
Explicitly separated Activity/Fragment event handling

### DIFF
--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/ActivityEvent.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/ActivityEvent.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.trello.rxlifecycle;
+
+/**
+ * Lifecycle events that can be emitted by Activities.
+ */
+public enum ActivityEvent {
+
+    CREATE,
+    START,
+    RESUME,
+    PAUSE,
+    STOP,
+    DESTROY
+
+}

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/FragmentEvent.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/FragmentEvent.java
@@ -15,9 +15,9 @@
 package com.trello.rxlifecycle;
 
 /**
- * Lifecycle events that can be emitted by Activities or Fragments.
+ * Lifecycle events that can be emitted by Fragments.
  */
-public enum LifecycleEvent {
+public enum FragmentEvent {
 
     ATTACH,
     CREATE,


### PR DESCRIPTION
It was too easy in past versions to make the mistake of binding to
the wrong lifecycle. Being more explicit makes it a bit wordier,
but it should prevent any potential problems.
