### PR TITLE
Use semantic versioning with flexible patch versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,9 @@ ext {
     buildToolsVersion = '23'
 
     // Define all dependencies in the base project, to unify & make it easy to update
-    rxJava = 'io.reactivex:rxjava:1.0.14'
-    rxBinding = 'com.jakewharton.rxbinding:rxbinding:0.2.0'
-    appCompat = 'com.android.support:appcompat-v7:23.0.0'
+    rxJava = 'io.reactivex:rxjava:1.0.+'
+    rxBinding = 'com.jakewharton.rxbinding:rxbinding:0.2.+'
+    appCompat = 'com.android.support:appcompat-v7:23.0.+'
     junit = 'junit:junit:4.12'
     mockito = 'org.mockito:mockito-core:1.10.19'
     robolectric = 'org.robolectric:robolectric:3.0'


### PR DESCRIPTION
This will allow users to upgrade the libraries without being locked down by another.