### PR TITLE
Updated Transformer's generic parameters

### DIFF
--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/ActivityLifecycleProvider.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/ActivityLifecycleProvider.java
@@ -24,7 +24,7 @@ public interface ActivityLifecycleProvider {
      * @param event the {@link ActivityEvent} that triggers unsubscription
      * @return a reusable {@link rx.Observable.Transformer} which unsubscribes when the event triggers.
      */
-    <T> Observable.Transformer<T, T> bindUntilEvent(ActivityEvent event);
+    <T> Observable.Transformer<? super T, ? extends T> bindUntilEvent(ActivityEvent event);
 
     /**
      * Binds a source until the next reasonable {@link ActivityEvent} occurs.
@@ -33,6 +33,6 @@ public interface ActivityLifecycleProvider {
      *
      * @return a reusable {@link rx.Observable.Transformer} which unsubscribes at the correct time.
      */
-    <T> Observable.Transformer<T, T> bindToLifecycle();
+    <T> Observable.Transformer<? super T, ? extends T> bindToLifecycle();
 
 }

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/FragmentLifecycleProvider.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/FragmentLifecycleProvider.java
@@ -24,7 +24,7 @@ public interface FragmentLifecycleProvider {
      * @param event the {@link FragmentEvent} that triggers unsubscription
      * @return a reusable {@link rx.Observable.Transformer} which unsubscribes when the event triggers.
      */
-    <T> Observable.Transformer<T, T> bindUntilEvent(FragmentEvent event);
+    <T> Observable.Transformer<? super T, ? extends T> bindUntilEvent(FragmentEvent event);
 
     /**
      * Binds a source until the next reasonable {@link FragmentEvent} occurs.
@@ -33,6 +33,6 @@ public interface FragmentLifecycleProvider {
      *
      * @return a reusable {@link rx.Observable.Transformer} which unsubscribes at the correct time.
      */
-    <T> Observable.Transformer<T, T> bindToLifecycle();
+    <T> Observable.Transformer<? super T, ? extends T> bindToLifecycle();
 
 }

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxActivity.java
@@ -17,12 +17,12 @@ public class RxActivity extends Activity implements ActivityLifecycleProvider {
     }
 
     @Override
-    public final <T> Observable.Transformer<T, T> bindUntilEvent(ActivityEvent event) {
+    public final <T> Observable.Transformer<? super T, ? extends T> bindUntilEvent(ActivityEvent event) {
         return RxLifecycle.bindUntilActivityEvent(lifecycleSubject, event);
     }
 
     @Override
-    public final <T> Observable.Transformer<T, T> bindToLifecycle() {
+    public final <T> Observable.Transformer<? super T, ? extends T> bindToLifecycle() {
         return RxLifecycle.bindActivity(lifecycleSubject);
     }
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxDialogFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxDialogFragment.java
@@ -18,12 +18,12 @@ public class RxDialogFragment extends DialogFragment implements FragmentLifecycl
     }
 
     @Override
-    public final <T> Observable.Transformer<T, T> bindUntilEvent(FragmentEvent event) {
+    public final <T> Observable.Transformer<? super T, ? extends T> bindUntilEvent(FragmentEvent event) {
         return RxLifecycle.bindUntilFragmentEvent(lifecycleSubject, event);
     }
 
     @Override
-    public final <T> Observable.Transformer<T, T> bindToLifecycle() {
+    public final <T> Observable.Transformer<? super T, ? extends T> bindToLifecycle() {
         return RxLifecycle.bindFragment(lifecycleSubject);
     }
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxFragment.java
@@ -18,12 +18,12 @@ public class RxFragment extends Fragment implements FragmentLifecycleProvider {
     }
 
     @Override
-    public final <T> Observable.Transformer<T, T> bindUntilEvent(FragmentEvent event) {
+    public final <T> Observable.Transformer<? super T, ? extends T> bindUntilEvent(FragmentEvent event) {
         return RxLifecycle.bindUntilFragmentEvent(lifecycleSubject, event);
     }
 
     @Override
-    public final <T> Observable.Transformer<T, T> bindToLifecycle() {
+    public final <T> Observable.Transformer<? super T, ? extends T> bindToLifecycle() {
         return RxLifecycle.bindFragment(lifecycleSubject);
     }
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxAppCompatActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxAppCompatActivity.java
@@ -18,12 +18,12 @@ public class RxAppCompatActivity extends AppCompatActivity implements ActivityLi
     }
 
     @Override
-    public final <T> Observable.Transformer<T, T> bindUntilEvent(ActivityEvent event) {
+    public final <T> Observable.Transformer<? super T, ? extends T> bindUntilEvent(ActivityEvent event) {
         return RxLifecycle.bindUntilActivityEvent(lifecycleSubject, event);
     }
 
     @Override
-    public final <T> Observable.Transformer<T, T> bindToLifecycle() {
+    public final <T> Observable.Transformer<? super T, ? extends T> bindToLifecycle() {
         return RxLifecycle.bindActivity(lifecycleSubject);
     }
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxDialogFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxDialogFragment.java
@@ -19,12 +19,12 @@ public class RxDialogFragment extends DialogFragment implements FragmentLifecycl
     }
 
     @Override
-    public final <T> Observable.Transformer<T, T> bindUntilEvent(FragmentEvent event) {
+    public final <T> Observable.Transformer<? super T, ? extends T> bindUntilEvent(FragmentEvent event) {
         return RxLifecycle.bindUntilFragmentEvent(lifecycleSubject, event);
     }
 
     @Override
-    public final <T> Observable.Transformer<T, T> bindToLifecycle() {
+    public final <T> Observable.Transformer<? super T, ? extends T> bindToLifecycle() {
         return RxLifecycle.bindFragment(lifecycleSubject);
     }
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragment.java
@@ -19,12 +19,12 @@ public class RxFragment extends Fragment implements FragmentLifecycleProvider {
     }
 
     @Override
-    public final <T> Observable.Transformer<T, T> bindUntilEvent(FragmentEvent event) {
+    public final <T> Observable.Transformer<? super T, ? extends T> bindUntilEvent(FragmentEvent event) {
         return RxLifecycle.bindUntilFragmentEvent(lifecycleSubject, event);
     }
 
     @Override
-    public final <T> Observable.Transformer<T, T> bindToLifecycle() {
+    public final <T> Observable.Transformer<? super T, ? extends T> bindToLifecycle() {
         return RxLifecycle.bindFragment(lifecycleSubject);
     }
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragmentActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragmentActivity.java
@@ -18,12 +18,12 @@ public class RxFragmentActivity extends FragmentActivity implements ActivityLife
     }
 
     @Override
-    public final <T> Observable.Transformer<T, T> bindUntilEvent(ActivityEvent event) {
+    public final <T> Observable.Transformer<? super T, ? extends T> bindUntilEvent(ActivityEvent event) {
         return RxLifecycle.bindUntilActivityEvent(lifecycleSubject, event);
     }
 
     @Override
-    public final <T> Observable.Transformer<T, T> bindToLifecycle() {
+    public final <T> Observable.Transformer<? super T, ? extends T> bindToLifecycle() {
         return RxLifecycle.bindActivity(lifecycleSubject);
     }
 

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/RxLifecycle.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/RxLifecycle.java
@@ -40,7 +40,7 @@ public class RxLifecycle {
      * @param event the event which should conclude notifications from the source
      * @return a reusable {@link Observable.Transformer} that unsubscribes the source at the specified event
      */
-    public static <T> Observable.Transformer<T, T> bindUntilFragmentEvent(
+    public static <T> Observable.Transformer<? super T, ? extends T> bindUntilFragmentEvent(
         final Observable<FragmentEvent> lifecycle, final FragmentEvent event) {
         return bindUntilEvent(lifecycle, event);
     }
@@ -57,12 +57,12 @@ public class RxLifecycle {
      * @param event the event which should conclude notifications from the source
      * @return a reusable {@link Observable.Transformer} that unsubscribes the source at the specified event
      */
-    public static <T> Observable.Transformer<T, T> bindUntilActivityEvent(
+    public static <T> Observable.Transformer<? super T, ? extends T> bindUntilActivityEvent(
         final Observable<ActivityEvent> lifecycle, final ActivityEvent event) {
         return bindUntilEvent(lifecycle, event);
     }
 
-    private static <T, R> Observable.Transformer<T, T> bindUntilEvent(final Observable<R> lifecycle,
+    private static <T, R> Observable.Transformer<? super T, ? extends T> bindUntilEvent(final Observable<R> lifecycle,
                                                                       final R event) {
         if (lifecycle == null) {
             throw new IllegalArgumentException("Lifecycle must be given");
@@ -104,7 +104,7 @@ public class RxLifecycle {
      * @param lifecycle the lifecycle sequence of an Activity
      * * @return a reusable {@link Observable.Transformer} that unsubscribes the source during the Activity lifecycle
      */
-    public static <T> Observable.Transformer<T, T> bindActivity(Observable<ActivityEvent> lifecycle) {
+    public static <T> Observable.Transformer<? super T, ? extends T> bindActivity(Observable<ActivityEvent> lifecycle) {
         return bind(lifecycle, ACTIVITY_LIFECYCLE);
     }
 
@@ -126,7 +126,7 @@ public class RxLifecycle {
      * @param lifecycle the lifecycle sequence of a Fragment
      * @return a reusable {@link Observable.Transformer} that unsubscribes the source during the Fragment lifecycle
      */
-    public static <T> Observable.Transformer<T, T> bindFragment(Observable<FragmentEvent> lifecycle) {
+    public static <T> Observable.Transformer<? super T, ? extends T> bindFragment(Observable<FragmentEvent> lifecycle) {
         return bind(lifecycle, FRAGMENT_LIFECYCLE);
     }
 
@@ -146,7 +146,7 @@ public class RxLifecycle {
      * @param view the view to bind the source sequence to
      * @return a reusable {@link Observable.Transformer} that unsubscribes the source during the View lifecycle
      */
-    public static <T> Observable.Transformer<T, T> bindView(final View view) {
+    public static <T> Observable.Transformer<? super T, ? extends T> bindView(final View view) {
         if (view == null) {
             throw new IllegalArgumentException("View must be given");
         }
@@ -168,7 +168,7 @@ public class RxLifecycle {
      * @param lifecycle the lifecycle sequence of a View
      * @return a reusable {@link Observable.Transformer} that unsubscribes the source during the View lifecycle
      */
-    public static <T, E> Observable.Transformer<T, T> bindView(final Observable<? extends E> lifecycle) {
+    public static <T, E> Observable.Transformer<? super T, ? extends T> bindView(final Observable<? extends E> lifecycle) {
         if (lifecycle == null) {
             throw new IllegalArgumentException("Lifecycle must be given");
         }
@@ -181,7 +181,7 @@ public class RxLifecycle {
         };
     }
 
-    private static <T, R> Observable.Transformer<T, T> bind(Observable<R> lifecycle,
+    private static <T, R> Observable.Transformer<? super T, ? extends T> bind(Observable<R> lifecycle,
                                                             final Func1<R, R> correspondingEvents) {
         if (lifecycle == null) {
             throw new IllegalArgumentException("Lifecycle must be given");


### PR DESCRIPTION
Return type `Transformer<T, T>` was updated to `Transformer<? super T, ? extends T>` to support Kotlin type inference.
This should fix #44 issue.