### PR TITLE
Implement support for binding to service lifecycles

### DIFF
--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxService.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxService.java
@@ -1,0 +1,76 @@
+package com.trello.rxlifecycle.components;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.support.annotation.CallSuper;
+import android.support.annotation.Nullable;
+
+import com.trello.rxlifecycle.RxLifecycle;
+import com.trello.rxlifecycle.ServiceEvent;
+
+import rx.Observable;
+import rx.subjects.BehaviorSubject;
+
+public class RxService extends Service implements ServiceLifecycleProvider {
+
+    private final BehaviorSubject<ServiceEvent> lifecycleSubject = BehaviorSubject.create();
+
+    @Override
+    public final Observable<ServiceEvent> lifecycle() {
+        return lifecycleSubject.asObservable();
+    }
+
+    @Override
+    public final <T> Observable.Transformer<? super T, ? extends T> bindUntilEvent(ServiceEvent event) {
+        return RxLifecycle.bindUntilServiceEvent(lifecycleSubject, event);
+    }
+
+    @Override
+    public final <T> Observable.Transformer<? super T, ? extends T> bindToLifecycle() {
+        return RxLifecycle.bindService(lifecycleSubject);
+    }
+
+    @Override
+    @CallSuper
+    public void onCreate() {
+        super.onCreate();
+        lifecycleSubject.onNext(ServiceEvent.CREATE);
+    }
+
+    @Nullable
+    @Override
+    @CallSuper
+    public IBinder onBind(Intent intent) {
+        lifecycleSubject.onNext(ServiceEvent.BIND);
+        return null;
+    }
+
+    @Override
+    @CallSuper
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        lifecycleSubject.onNext(ServiceEvent.START_COMMAND);
+        return super.onStartCommand(intent, flags, startId);
+    }
+
+    @Override
+    @CallSuper
+    public void onDestroy() {
+        lifecycleSubject.onNext(ServiceEvent.DESTROY);
+        super.onDestroy();
+    }
+
+    @Override
+    @CallSuper
+    public boolean onUnbind(Intent intent) {
+        lifecycleSubject.onNext(ServiceEvent.UNBIND);
+        return super.onUnbind(intent);
+    }
+
+    @Override
+    @CallSuper
+    public void onRebind(Intent intent) {
+        super.onRebind(intent);
+        lifecycleSubject.onNext(ServiceEvent.REBIND);
+    }
+}

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/ServiceLifecycleProvider.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/ServiceLifecycleProvider.java
@@ -1,0 +1,38 @@
+package com.trello.rxlifecycle.components;
+
+import com.trello.rxlifecycle.ServiceEvent;
+
+import rx.Observable;
+
+/**
+ * Common interface for all RxService extensions.
+ *
+ * Useful if you are writing utilities on top of rxlifecycle-components,
+ * or you are implementing your own component not supported in this library.
+ */
+public interface ServiceLifecycleProvider {
+
+    /**
+     * @return a sequence of {@link android.app.Activity} lifecycle events
+     */
+    Observable<ServiceEvent> lifecycle();
+
+    /**
+     * Binds a source until a specific {@link ServiceEvent} occurs.
+     * <p>
+     * Intended for use with {@link Observable#compose(Observable.Transformer)}
+     *
+     * @param event the {@link ServiceEvent} that triggers unsubscription
+     * @return a reusable {@link rx.Observable.Transformer} which unsubscribes when the event triggers.
+     */
+    <T> Observable.Transformer<? super T, ? extends T> bindUntilEvent(ServiceEvent event);
+
+    /**
+     * Binds a source until the next reasonable {@link ServiceEvent} occurs.
+     * <p>
+     * Intended for use with {@link Observable#compose(Observable.Transformer)}
+     *
+     * @return a reusable {@link rx.Observable.Transformer} which unsubscribes at the correct time.
+     */
+    <T> Observable.Transformer<? super T, ? extends T> bindToLifecycle();
+}

--- a/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/RxServiceLifecycleTest.java
+++ b/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/RxServiceLifecycleTest.java
@@ -1,0 +1,123 @@
+package com.trello.rxlifecycle.components;
+
+import com.trello.rxlifecycle.ServiceEvent;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.util.ServiceController;
+
+import rx.Observable;
+import rx.observers.TestSubscriber;
+import rx.subjects.PublishSubject;
+
+import static org.junit.Assert.assertFalse;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class RxServiceLifecycleTest {
+
+    private Observable<Object> observable;
+
+    @Before
+    public void setup() {
+        observable = PublishSubject.create().asObservable();
+    }
+
+    @Test
+    public void testRxActivity() {
+        testLifecycle(Robolectric.buildService(RxService.class));
+        testBindUntilEvent(Robolectric.buildService(RxService.class));
+        testBindToLifecycle(Robolectric.buildService(RxService.class));
+    }
+
+    private void testLifecycle(ServiceController<? extends ServiceLifecycleProvider> controller) {
+        ServiceLifecycleProvider activity = controller.get();
+
+        TestSubscriber<ServiceEvent> testSubscriber = new TestSubscriber<>();
+        activity.lifecycle().subscribe(testSubscriber);
+
+        controller.create();
+        controller.startCommand(0, 0);
+        controller.bind();
+        controller.rebind();
+        controller.unbind();
+        controller.destroy();
+
+        testSubscriber.assertValues(
+                ServiceEvent.CREATE,
+                ServiceEvent.START_COMMAND,
+                ServiceEvent.BIND,
+                ServiceEvent.REBIND,
+                ServiceEvent.UNBIND,
+                ServiceEvent.DESTROY
+        );
+    }
+
+    // Tests bindUntil for any given RxActivityLifecycle implementation
+    private void testBindUntilEvent(ServiceController<? extends ServiceLifecycleProvider> controller) {
+        ServiceLifecycleProvider activity = controller.get();
+
+        TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
+        observable.compose(activity.bindUntilEvent(ServiceEvent.UNBIND)).subscribe(testSubscriber);
+
+        controller.create();
+        assertFalse(testSubscriber.isUnsubscribed());
+        controller.startCommand(0, 0);
+        assertFalse(testSubscriber.isUnsubscribed());
+        controller.bind();
+        assertFalse(testSubscriber.isUnsubscribed());
+        controller.rebind();
+        assertFalse(testSubscriber.isUnsubscribed());
+        controller.unbind();
+        testSubscriber.assertCompleted();
+        testSubscriber.assertUnsubscribed();
+    }
+
+    // Tests bindToLifecycle for any given RxActivityLifecycle implementation
+    private void testBindToLifecycle(ServiceController<? extends ServiceLifecycleProvider> controller) {
+        ServiceLifecycleProvider activity = controller.get();
+
+        controller.create();
+        TestSubscriber<Object> createTestSub = new TestSubscriber<>();
+        observable.compose(activity.bindToLifecycle()).subscribe(createTestSub);
+
+        controller.startCommand(0, 0);
+        assertFalse(createTestSub.isUnsubscribed());
+        TestSubscriber<Object> startTestSub = new TestSubscriber<>();
+        observable.compose(activity.bindToLifecycle()).subscribe(startTestSub);
+
+        controller.bind();
+        assertFalse(createTestSub.isUnsubscribed());
+        assertFalse(startTestSub.isUnsubscribed());
+        TestSubscriber<Object> bindTestSub = new TestSubscriber<>();
+        observable.compose(activity.bindToLifecycle()).subscribe(bindTestSub);
+
+        controller.rebind();
+        assertFalse(createTestSub.isUnsubscribed());
+        assertFalse(startTestSub.isUnsubscribed());
+        assertFalse(bindTestSub.isUnsubscribed());
+        TestSubscriber<Object> rebindTestSub = new TestSubscriber<>();
+        observable.compose(activity.bindToLifecycle()).subscribe(rebindTestSub);
+
+        controller.unbind();
+        assertFalse(createTestSub.isUnsubscribed());
+        bindTestSub.assertCompleted();
+        bindTestSub.assertUnsubscribed();
+        rebindTestSub.assertCompleted();
+        rebindTestSub.assertUnsubscribed();
+        TestSubscriber<Object> unbindTestSub = new TestSubscriber<>();
+        observable.compose(activity.bindToLifecycle()).subscribe(unbindTestSub);
+
+        controller.destroy();
+        createTestSub.assertCompleted();
+        createTestSub.assertUnsubscribed();
+        startTestSub.assertCompleted();
+        startTestSub.assertUnsubscribed();
+        unbindTestSub.assertCompleted();
+        unbindTestSub.assertUnsubscribed();
+    }
+}

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/ServiceEvent.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/ServiceEvent.java
@@ -1,0 +1,15 @@
+package com.trello.rxlifecycle;
+
+/**
+ * Lifecycle events that can be emitted by Services.
+ */
+public enum ServiceEvent {
+
+    CREATE,
+    START_COMMAND,
+    BIND,
+    UNBIND,
+    REBIND,
+    DESTROY
+
+}


### PR DESCRIPTION
I'm not heavily experienced with services, so open to discussion on what `REBIND` and `START_COMMAND` should map to. Otherwise it's pretty straightforward.

Another thing: Service lifecycle callbacks aren't always void, which makes things a little awkward. Services are abstract usually, so the user needs to know to override the proper methods in `RxService` if they use it, which could not be obvious if they're not familiar with services. Thought about making RxService abstract, but figured it was obvious already and just made testing a headache.