### PR TITLE
Add CallSuper annotation to provided Activity, Context and Dialog components

### DIFF
--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxActivity.java
@@ -2,8 +2,11 @@ package com.trello.rxlifecycle.components;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
+
 import com.trello.rxlifecycle.ActivityEvent;
 import com.trello.rxlifecycle.RxLifecycle;
+
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
@@ -27,36 +30,42 @@ public class RxActivity extends Activity implements ActivityLifecycleProvider {
     }
 
     @Override
+    @CallSuper
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         lifecycleSubject.onNext(ActivityEvent.CREATE);
     }
 
     @Override
+    @CallSuper
     protected void onStart() {
         super.onStart();
         lifecycleSubject.onNext(ActivityEvent.START);
     }
 
     @Override
+    @CallSuper
     protected void onResume() {
         super.onResume();
         lifecycleSubject.onNext(ActivityEvent.RESUME);
     }
 
     @Override
+    @CallSuper
     protected void onPause() {
         lifecycleSubject.onNext(ActivityEvent.PAUSE);
         super.onPause();
     }
 
     @Override
+    @CallSuper
     protected void onStop() {
         lifecycleSubject.onNext(ActivityEvent.STOP);
         super.onStop();
     }
 
     @Override
+    @CallSuper
     protected void onDestroy() {
         lifecycleSubject.onNext(ActivityEvent.DESTROY);
         super.onDestroy();

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxDialogFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxDialogFragment.java
@@ -2,9 +2,12 @@ package com.trello.rxlifecycle.components;
 
 import android.app.DialogFragment;
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.view.View;
+
 import com.trello.rxlifecycle.FragmentEvent;
 import com.trello.rxlifecycle.RxLifecycle;
+
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
@@ -28,60 +31,70 @@ public class RxDialogFragment extends DialogFragment implements FragmentLifecycl
     }
 
     @Override
+    @CallSuper
     public void onAttach(android.app.Activity activity) {
         super.onAttach(activity);
         lifecycleSubject.onNext(FragmentEvent.ATTACH);
     }
 
     @Override
+    @CallSuper
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         lifecycleSubject.onNext(FragmentEvent.CREATE);
     }
 
     @Override
+    @CallSuper
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         lifecycleSubject.onNext(FragmentEvent.CREATE_VIEW);
     }
 
     @Override
+    @CallSuper
     public void onStart() {
         super.onStart();
         lifecycleSubject.onNext(FragmentEvent.START);
     }
 
     @Override
+    @CallSuper
     public void onResume() {
         super.onResume();
         lifecycleSubject.onNext(FragmentEvent.RESUME);
     }
 
     @Override
+    @CallSuper
     public void onPause() {
         lifecycleSubject.onNext(FragmentEvent.PAUSE);
         super.onPause();
     }
 
     @Override
+    @CallSuper
     public void onStop() {
         lifecycleSubject.onNext(FragmentEvent.STOP);
         super.onStop();
     }
 
     @Override
+    @CallSuper
     public void onDestroyView() {
         lifecycleSubject.onNext(FragmentEvent.DESTROY_VIEW);
         super.onDestroyView();
     }
 
     @Override
+    @CallSuper
     public void onDestroy() {
         lifecycleSubject.onNext(FragmentEvent.DESTROY);
         super.onDestroy();
     }
 
     @Override
+    @CallSuper
     public void onDetach() {
         lifecycleSubject.onNext(FragmentEvent.DETACH);
         super.onDetach();

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxFragment.java
@@ -2,9 +2,12 @@ package com.trello.rxlifecycle.components;
 
 import android.app.Fragment;
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.view.View;
+
 import com.trello.rxlifecycle.FragmentEvent;
 import com.trello.rxlifecycle.RxLifecycle;
+
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
@@ -28,60 +31,70 @@ public class RxFragment extends Fragment implements FragmentLifecycleProvider {
     }
 
     @Override
+    @CallSuper
     public void onAttach(android.app.Activity activity) {
         super.onAttach(activity);
         lifecycleSubject.onNext(FragmentEvent.ATTACH);
     }
 
     @Override
+    @CallSuper
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         lifecycleSubject.onNext(FragmentEvent.CREATE);
     }
 
     @Override
+    @CallSuper
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         lifecycleSubject.onNext(FragmentEvent.CREATE_VIEW);
     }
 
     @Override
+    @CallSuper
     public void onStart() {
         super.onStart();
         lifecycleSubject.onNext(FragmentEvent.START);
     }
 
     @Override
+    @CallSuper
     public void onResume() {
         super.onResume();
         lifecycleSubject.onNext(FragmentEvent.RESUME);
     }
 
     @Override
+    @CallSuper
     public void onPause() {
         lifecycleSubject.onNext(FragmentEvent.PAUSE);
         super.onPause();
     }
 
     @Override
+    @CallSuper
     public void onStop() {
         lifecycleSubject.onNext(FragmentEvent.STOP);
         super.onStop();
     }
 
     @Override
+    @CallSuper
     public void onDestroyView() {
         lifecycleSubject.onNext(FragmentEvent.DESTROY_VIEW);
         super.onDestroyView();
     }
 
     @Override
+    @CallSuper
     public void onDestroy() {
         lifecycleSubject.onNext(FragmentEvent.DESTROY);
         super.onDestroy();
     }
 
     @Override
+    @CallSuper
     public void onDetach() {
         lifecycleSubject.onNext(FragmentEvent.DETACH);
         super.onDetach();

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxAppCompatActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxAppCompatActivity.java
@@ -1,10 +1,13 @@
 package com.trello.rxlifecycle.components.support;
 
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.v7.app.AppCompatActivity;
+
 import com.trello.rxlifecycle.ActivityEvent;
 import com.trello.rxlifecycle.RxLifecycle;
 import com.trello.rxlifecycle.components.ActivityLifecycleProvider;
+
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
@@ -28,36 +31,42 @@ public class RxAppCompatActivity extends AppCompatActivity implements ActivityLi
     }
 
     @Override
+    @CallSuper
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         lifecycleSubject.onNext(ActivityEvent.CREATE);
     }
 
     @Override
+    @CallSuper
     protected void onStart() {
         super.onStart();
         lifecycleSubject.onNext(ActivityEvent.START);
     }
 
     @Override
+    @CallSuper
     protected void onResume() {
         super.onResume();
         lifecycleSubject.onNext(ActivityEvent.RESUME);
     }
 
     @Override
+    @CallSuper
     protected void onPause() {
         lifecycleSubject.onNext(ActivityEvent.PAUSE);
         super.onPause();
     }
 
     @Override
+    @CallSuper
     protected void onStop() {
         lifecycleSubject.onNext(ActivityEvent.STOP);
         super.onStop();
     }
 
     @Override
+    @CallSuper
     protected void onDestroy() {
         lifecycleSubject.onNext(ActivityEvent.DESTROY);
         super.onDestroy();

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxDialogFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxDialogFragment.java
@@ -1,11 +1,14 @@
 package com.trello.rxlifecycle.components.support;
 
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.v4.app.DialogFragment;
 import android.view.View;
+
 import com.trello.rxlifecycle.FragmentEvent;
 import com.trello.rxlifecycle.RxLifecycle;
 import com.trello.rxlifecycle.components.FragmentLifecycleProvider;
+
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
@@ -29,60 +32,70 @@ public class RxDialogFragment extends DialogFragment implements FragmentLifecycl
     }
 
     @Override
+    @CallSuper
     public void onAttach(android.app.Activity activity) {
         super.onAttach(activity);
         lifecycleSubject.onNext(FragmentEvent.ATTACH);
     }
 
     @Override
+    @CallSuper
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         lifecycleSubject.onNext(FragmentEvent.CREATE);
     }
 
     @Override
+    @CallSuper
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         lifecycleSubject.onNext(FragmentEvent.CREATE_VIEW);
     }
 
     @Override
+    @CallSuper
     public void onStart() {
         super.onStart();
         lifecycleSubject.onNext(FragmentEvent.START);
     }
 
     @Override
+    @CallSuper
     public void onResume() {
         super.onResume();
         lifecycleSubject.onNext(FragmentEvent.RESUME);
     }
 
     @Override
+    @CallSuper
     public void onPause() {
         lifecycleSubject.onNext(FragmentEvent.PAUSE);
         super.onPause();
     }
 
     @Override
+    @CallSuper
     public void onStop() {
         lifecycleSubject.onNext(FragmentEvent.STOP);
         super.onStop();
     }
 
     @Override
+    @CallSuper
     public void onDestroyView() {
         lifecycleSubject.onNext(FragmentEvent.DESTROY_VIEW);
         super.onDestroyView();
     }
 
     @Override
+    @CallSuper
     public void onDestroy() {
         lifecycleSubject.onNext(FragmentEvent.DESTROY);
         super.onDestroy();
     }
 
     @Override
+    @CallSuper
     public void onDetach() {
         lifecycleSubject.onNext(FragmentEvent.DETACH);
         super.onDetach();

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragmentActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragmentActivity.java
@@ -1,10 +1,13 @@
 package com.trello.rxlifecycle.components.support;
 
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.v4.app.FragmentActivity;
+
 import com.trello.rxlifecycle.ActivityEvent;
 import com.trello.rxlifecycle.RxLifecycle;
 import com.trello.rxlifecycle.components.ActivityLifecycleProvider;
+
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
@@ -28,36 +31,42 @@ public class RxFragmentActivity extends FragmentActivity implements ActivityLife
     }
 
     @Override
+    @CallSuper
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         lifecycleSubject.onNext(ActivityEvent.CREATE);
     }
 
     @Override
+    @CallSuper
     protected void onStart() {
         super.onStart();
         lifecycleSubject.onNext(ActivityEvent.START);
     }
 
     @Override
+    @CallSuper
     protected void onResume() {
         super.onResume();
         lifecycleSubject.onNext(ActivityEvent.RESUME);
     }
 
     @Override
+    @CallSuper
     protected void onPause() {
         lifecycleSubject.onNext(ActivityEvent.PAUSE);
         super.onPause();
     }
 
     @Override
+    @CallSuper
     protected void onStop() {
         lifecycleSubject.onNext(ActivityEvent.STOP);
         super.onStop();
     }
 
     @Override
+    @CallSuper
     protected void onDestroy() {
         lifecycleSubject.onNext(ActivityEvent.DESTROY);
         super.onDestroy();


### PR DESCRIPTION
The advantage is pretty simple. When you extend from one of these classes and override one method but don't call the super method you'll get a warning in Android Studio.