### PR TITLE
Moved Provider interfaces into core library

### DIFF
--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.annotation.CallSuper;
 
 import com.trello.rxlifecycle.ActivityEvent;
+import com.trello.rxlifecycle.ActivityLifecycleProvider;
 import com.trello.rxlifecycle.RxLifecycle;
 
 import rx.Observable;

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxDialogFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxDialogFragment.java
@@ -6,6 +6,7 @@ import android.support.annotation.CallSuper;
 import android.view.View;
 
 import com.trello.rxlifecycle.FragmentEvent;
+import com.trello.rxlifecycle.FragmentLifecycleProvider;
 import com.trello.rxlifecycle.RxLifecycle;
 
 import rx.Observable;

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxFragment.java
@@ -6,6 +6,7 @@ import android.support.annotation.CallSuper;
 import android.view.View;
 
 import com.trello.rxlifecycle.FragmentEvent;
+import com.trello.rxlifecycle.FragmentLifecycleProvider;
 import com.trello.rxlifecycle.RxLifecycle;
 
 import rx.Observable;

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxAppCompatActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxAppCompatActivity.java
@@ -6,7 +6,7 @@ import android.support.v7.app.AppCompatActivity;
 
 import com.trello.rxlifecycle.ActivityEvent;
 import com.trello.rxlifecycle.RxLifecycle;
-import com.trello.rxlifecycle.components.ActivityLifecycleProvider;
+import com.trello.rxlifecycle.ActivityLifecycleProvider;
 
 import rx.Observable;
 import rx.subjects.BehaviorSubject;

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxDialogFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxDialogFragment.java
@@ -7,7 +7,7 @@ import android.view.View;
 
 import com.trello.rxlifecycle.FragmentEvent;
 import com.trello.rxlifecycle.RxLifecycle;
-import com.trello.rxlifecycle.components.FragmentLifecycleProvider;
+import com.trello.rxlifecycle.FragmentLifecycleProvider;
 
 import rx.Observable;
 import rx.subjects.BehaviorSubject;

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragment.java
@@ -5,7 +5,7 @@ import android.support.v4.app.Fragment;
 import android.view.View;
 import com.trello.rxlifecycle.FragmentEvent;
 import com.trello.rxlifecycle.RxLifecycle;
-import com.trello.rxlifecycle.components.FragmentLifecycleProvider;
+import com.trello.rxlifecycle.FragmentLifecycleProvider;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragmentActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragmentActivity.java
@@ -6,7 +6,7 @@ import android.support.v4.app.FragmentActivity;
 
 import com.trello.rxlifecycle.ActivityEvent;
 import com.trello.rxlifecycle.RxLifecycle;
-import com.trello.rxlifecycle.components.ActivityLifecycleProvider;
+import com.trello.rxlifecycle.ActivityLifecycleProvider;
 
 import rx.Observable;
 import rx.subjects.BehaviorSubject;

--- a/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/RxActivityLifecycleTest.java
+++ b/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/RxActivityLifecycleTest.java
@@ -15,6 +15,7 @@
 package com.trello.rxlifecycle.components;
 
 import com.trello.rxlifecycle.ActivityEvent;
+import com.trello.rxlifecycle.ActivityLifecycleProvider;
 import com.trello.rxlifecycle.components.support.RxFragmentActivity;
 import org.junit.Before;
 import org.junit.Test;

--- a/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/RxFragmentLifecycleTest.java
+++ b/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/RxFragmentLifecycleTest.java
@@ -16,6 +16,7 @@ package com.trello.rxlifecycle.components;
 
 import android.app.Fragment;
 import com.trello.rxlifecycle.FragmentEvent;
+import com.trello.rxlifecycle.FragmentLifecycleProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/support/RxSupportFragmentLifecycleTest.java
+++ b/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/support/RxSupportFragmentLifecycleTest.java
@@ -17,7 +17,7 @@ package com.trello.rxlifecycle.components.support;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import com.trello.rxlifecycle.FragmentEvent;
-import com.trello.rxlifecycle.components.FragmentLifecycleProvider;
+import com.trello.rxlifecycle.FragmentLifecycleProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/ActivityLifecycleProvider.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/ActivityLifecycleProvider.java
@@ -1,6 +1,5 @@
-package com.trello.rxlifecycle.components;
+package com.trello.rxlifecycle;
 
-import com.trello.rxlifecycle.ActivityEvent;
 import rx.Observable;
 
 /**

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/FragmentLifecycleProvider.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/FragmentLifecycleProvider.java
@@ -1,4 +1,4 @@
-package com.trello.rxlifecycle.components;
+package com.trello.rxlifecycle;
 
 import com.trello.rxlifecycle.FragmentEvent;
 import rx.Observable;


### PR DESCRIPTION
This will allow multiple implementations of the provider to
exist without having everyone depending on rxlifecycle-components