### PR TITLE
rxlifecycle-kotlin module added with bind() syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,15 @@ If you want some kotlin goodness, you can use bind() syntax
 
 ```java
 myObservable
-    .bind(myView) //bind(myRxActivity or myRxFragment)
-    .subscribe()
+    .bindToLifecycle(myView)
+    .subscribe { }
+
+```
+
+```java
+myObservable
+    .bindUntilEvent(myRxActivity, STOP)
+    .subscribe { }
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ public class MyActivity extends NaviActivity {
 }
 ```
 
+If you want some kotlin goodness, you can use bind() syntax
+
+```java
+myObservable
+    .bind(myView) //bind(myRxActivity or myRxFragment)
+    .subscribe()
+
+```
+
 ## Unsubscription
 
 RxLifecycle does not actually unsubscribe the sequence. It terminates it by emitting `onCompleted()`, which ends the
@@ -91,6 +100,9 @@ compile 'com.trello:rxlifecycle-components:0.4.0'
 
 // If you want to use Navi for providers
 compile 'com.trello:rxlifecycle-navi:0.4.0'
+
+// If you wat to use Kotlin syntax
+compile 'com.trello:rxlifecycle-kotlin:0.4.0'
 ```
 
 ## License

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext {
         //version here to share between build script and projects
         //todo https://github.com/JetBrains/kotlin/pull/775 : remove if it will be merged
-        verKotlin = '1.0.0-rc-1036'
+        verKotlin = '1.0.0'
     }
     repositories {
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,15 @@
 buildscript {
+    ext {
+        //version here to share between build script and projects
+        //todo https://github.com/JetBrains/kotlin/pull/775 : remove if it will be merged
+        verKotlin = '1.0.0-rc-1036'
+    }
     repositories {
         jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$verKotlin"
     }
 }
 
@@ -22,6 +28,7 @@ ext {
     rxJava = 'io.reactivex:rxjava:1.0.16'
     rxBinding = 'com.jakewharton.rxbinding:rxbinding:0.3.0'
     navi = 'com.trello:navi:0.1.3'
+    kotlinStdlib = "org.jetbrains.kotlin:kotlin-stdlib:$verKotlin"
     appCompat = 'com.android.support:appcompat-v7:23.1.1'
     junit = 'junit:junit:4.12'
     mockito = 'org.mockito:mockito-core:1.10.19'

--- a/rxlifecycle-kotlin/build.gradle
+++ b/rxlifecycle-kotlin/build.gradle
@@ -1,0 +1,31 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
+
+    defaultConfig {
+        minSdkVersion rootProject.ext.minSdkVersion
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile kotlinStdlib
+    compile project(':rxlifecycle')
+
+    compile rootProject.ext.rxJava
+
+    compile rootProject.ext.appCompat
+
+    testCompile rootProject.ext.junit
+    testCompile rootProject.ext.mockito
+    testCompile rootProject.ext.robolectric
+}
+
+apply from: "$rootDir/gradle/artifacts.gradle"
+apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/rxlifecycle-kotlin/build.gradle
+++ b/rxlifecycle-kotlin/build.gradle
@@ -17,14 +17,6 @@ repositories {
 dependencies {
     compile kotlinStdlib
     compile project(':rxlifecycle')
-
-    compile rootProject.ext.rxJava
-
-    compile rootProject.ext.appCompat
-
-    testCompile rootProject.ext.junit
-    testCompile rootProject.ext.mockito
-    testCompile rootProject.ext.robolectric
 }
 
 apply from: "$rootDir/gradle/artifacts.gradle"

--- a/rxlifecycle-kotlin/gradle.properties
+++ b/rxlifecycle-kotlin/gradle.properties
@@ -1,0 +1,4 @@
+POM_NAME=RxLifecycle-Kotlin
+POM_DESCRIPTION=RxLifecycle-Kotlin
+POM_ARTIFACT_ID=rxlifecycle-Kotlin
+POM_PACKAGING=aar

--- a/rxlifecycle-kotlin/gradle.properties
+++ b/rxlifecycle-kotlin/gradle.properties
@@ -1,4 +1,4 @@
-POM_NAME=RxLifecycle-Kotlin
-POM_DESCRIPTION=RxLifecycle-Kotlin
-POM_ARTIFACT_ID=rxlifecycle-Kotlin
+POM_NAME=RxLifecycle-kotlin
+POM_DESCRIPTION=RxLifecycle-kotlin
+POM_ARTIFACT_ID=rxlifecycle-kotlin
 POM_PACKAGING=aar

--- a/rxlifecycle-kotlin/src/main/AndroidManifest.xml
+++ b/rxlifecycle-kotlin/src/main/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<manifest package="com.trello.rxlifecycle.kotlin" />

--- a/rxlifecycle-kotlin/src/main/java/com/trello/rxlifecycle/kotlin/rxlifecycle.kt
+++ b/rxlifecycle-kotlin/src/main/java/com/trello/rxlifecycle/kotlin/rxlifecycle.kt
@@ -1,13 +1,29 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.trello.rxlifecycle.kotlin
 
 import android.view.View
-import com.trello.rxlifecycle.ActivityLifecycleProvider
-import com.trello.rxlifecycle.FragmentLifecycleProvider
-import com.trello.rxlifecycle.RxLifecycle
+import com.trello.rxlifecycle.*
 import rx.Observable
 
-fun <T> Observable<T>.bind(activity: ActivityLifecycleProvider): Observable<T> = this.compose<T>(activity.bindToLifecycle<T>())
+fun <T> Observable<T>.bindToLifecycle(activity: ActivityLifecycleProvider): Observable<T> = this.compose<T>(activity.bindToLifecycle<T>())
 
-fun <T> Observable<T>.bind(fragment: FragmentLifecycleProvider): Observable<T> = this.compose<T>(fragment.bindToLifecycle<T>())
+fun <T> Observable<T>.bindUntilEvent(activity: ActivityLifecycleProvider, event: ActivityEvent): Observable<T> = this.compose<T>(activity.bindUntilEvent(event))
 
-fun <T> Observable<T>.bind(view: View): Observable<T> = this.compose<T>(RxLifecycle.bindView(view))
+fun <T> Observable<T>.bindToLifecycle(fragment: FragmentLifecycleProvider): Observable<T> = this.compose<T>(fragment.bindToLifecycle<T>())
+
+fun <T> Observable<T>.bindUntilEvent(fragment: FragmentLifecycleProvider, event: FragmentEvent): Observable<T> = this.compose<T>(fragment.bindUntilEvent(event))
+
+fun <T> Observable<T>.bindToLifecycle(view: View): Observable<T> = this.compose<T>(RxLifecycle.bindView(view))

--- a/rxlifecycle-kotlin/src/main/java/com/trello/rxlifecycle/kotlin/rxlifecycle.kt
+++ b/rxlifecycle-kotlin/src/main/java/com/trello/rxlifecycle/kotlin/rxlifecycle.kt
@@ -1,0 +1,13 @@
+package com.trello.rxlifecycle.kotlin
+
+import android.view.View
+import com.trello.rxlifecycle.ActivityLifecycleProvider
+import com.trello.rxlifecycle.FragmentLifecycleProvider
+import com.trello.rxlifecycle.RxLifecycle
+import rx.Observable
+
+fun <T> Observable<T>.bind(activity: ActivityLifecycleProvider): Observable<T> = this.compose<T>(activity.bindToLifecycle<T>())
+
+fun <T> Observable<T>.bind(fragment: FragmentLifecycleProvider): Observable<T> = this.compose<T>(fragment.bindToLifecycle<T>())
+
+fun <T> Observable<T>.bind(view: View): Observable<T> = this.compose<T>(RxLifecycle.bindView(view))

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
-include ':rxlifecycle', ':rxlifecycle-kotlin'
+include ':rxlifecycle'
 include ':rxlifecycle-components'
 include ':rxlifecycle-navi'
+include ':rxlifecycle-kotlin'
 include ':rxlifecycle-sample'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-include ':rxlifecycle'
+include ':rxlifecycle', ':rxlifecycle-kotlin'
 include ':rxlifecycle-components'
 include ':rxlifecycle-navi'
 include ':rxlifecycle-sample'


### PR DESCRIPTION
address reverted #58 , and some nice new syntax

Not sure if any tests will work here.