### PR TITLE
Made bindUntilEvent() public, deprecated more specific calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can then end the sequence explicitly when an event occurs:
 
 ```java
 myObservable
-    .compose(RxLifecycle.bindUntilActivityEvent(lifecycle, ActivityEvent.DESTROY))
+    .compose(RxLifecycle.bindUntilEvent(lifecycle, ActivityEvent.DESTROY))
     .subscribe();
 ```
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxActivity.java
@@ -22,7 +22,7 @@ public class RxActivity extends Activity implements ActivityLifecycleProvider {
 
     @Override
     public final <T> Observable.Transformer<T, T> bindUntilEvent(ActivityEvent event) {
-        return RxLifecycle.bindUntilActivityEvent(lifecycleSubject, event);
+        return RxLifecycle.bindUntilEvent(lifecycleSubject, event);
     }
 
     @Override

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxDialogFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxDialogFragment.java
@@ -23,7 +23,7 @@ public class RxDialogFragment extends DialogFragment implements FragmentLifecycl
 
     @Override
     public final <T> Observable.Transformer<T, T> bindUntilEvent(FragmentEvent event) {
-        return RxLifecycle.bindUntilFragmentEvent(lifecycleSubject, event);
+        return RxLifecycle.bindUntilEvent(lifecycleSubject, event);
     }
 
     @Override

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxFragment.java
@@ -23,7 +23,7 @@ public class RxFragment extends Fragment implements FragmentLifecycleProvider {
 
     @Override
     public final <T> Observable.Transformer<T, T> bindUntilEvent(FragmentEvent event) {
-        return RxLifecycle.bindUntilFragmentEvent(lifecycleSubject, event);
+        return RxLifecycle.bindUntilEvent(lifecycleSubject, event);
     }
 
     @Override

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxAppCompatActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxAppCompatActivity.java
@@ -22,7 +22,7 @@ public class RxAppCompatActivity extends AppCompatActivity implements ActivityLi
 
     @Override
     public final <T> Observable.Transformer<T, T> bindUntilEvent(ActivityEvent event) {
-        return RxLifecycle.bindUntilActivityEvent(lifecycleSubject, event);
+        return RxLifecycle.bindUntilEvent(lifecycleSubject, event);
     }
 
     @Override

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxDialogFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxDialogFragment.java
@@ -23,7 +23,7 @@ public class RxDialogFragment extends DialogFragment implements FragmentLifecycl
 
     @Override
     public final <T> Observable.Transformer<T, T> bindUntilEvent(FragmentEvent event) {
-        return RxLifecycle.bindUntilFragmentEvent(lifecycleSubject, event);
+        return RxLifecycle.bindUntilEvent(lifecycleSubject, event);
     }
 
     @Override

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragment.java
@@ -20,7 +20,7 @@ public class RxFragment extends Fragment implements FragmentLifecycleProvider {
 
     @Override
     public final <T> Observable.Transformer<T, T> bindUntilEvent(FragmentEvent event) {
-        return RxLifecycle.bindUntilFragmentEvent(lifecycleSubject, event);
+        return RxLifecycle.bindUntilEvent(lifecycleSubject, event);
     }
 
     @Override

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragmentActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragmentActivity.java
@@ -22,7 +22,7 @@ public class RxFragmentActivity extends FragmentActivity implements ActivityLife
 
     @Override
     public final <T> Observable.Transformer<T, T> bindUntilEvent(ActivityEvent event) {
-        return RxLifecycle.bindUntilActivityEvent(lifecycleSubject, event);
+        return RxLifecycle.bindUntilEvent(lifecycleSubject, event);
     }
 
     @Override

--- a/rxlifecycle-navi/src/main/java/com/trello/rxlifecycle/navi/ActivityLifecycleProviderImpl.java
+++ b/rxlifecycle-navi/src/main/java/com/trello/rxlifecycle/navi/ActivityLifecycleProviderImpl.java
@@ -30,7 +30,7 @@ final class ActivityLifecycleProviderImpl implements ActivityLifecycleProvider {
 
     @Override
     public <T> Observable.Transformer<T, T> bindUntilEvent(ActivityEvent event) {
-        return RxLifecycle.bindUntilActivityEvent(lifecycleSubject, event);
+        return RxLifecycle.bindUntilEvent(lifecycleSubject, event);
     }
 
     @Override

--- a/rxlifecycle-navi/src/main/java/com/trello/rxlifecycle/navi/FragmentLifecycleProviderImpl.java
+++ b/rxlifecycle-navi/src/main/java/com/trello/rxlifecycle/navi/FragmentLifecycleProviderImpl.java
@@ -31,7 +31,7 @@ final class FragmentLifecycleProviderImpl implements FragmentLifecycleProvider {
 
     @Override
     public <T> Observable.Transformer<T, T> bindUntilEvent(FragmentEvent event) {
-        return RxLifecycle.bindUntilFragmentEvent(lifecycleSubject, event);
+        return RxLifecycle.bindUntilEvent(lifecycleSubject, event);
     }
 
     @Override

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/RxLifecycle.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/RxLifecycle.java
@@ -29,41 +29,41 @@ public class RxLifecycle {
     }
 
     /**
-     * Binds the given source to a Fragment lifecycle.
-     * <p>
-     * When the lifecycle event occurs, the source will cease to emit any notifications.
-     * <p>
-     * Use with {@link Observable#compose(Observable.Transformer)}:
-     * {@code source.compose(RxLifecycle.bindUntilEvent(lifecycle, FragmentEvent.STOP)).subscribe()}
+     * Deprecated and will be removed in a future release.
      *
-     * @param lifecycle the Fragment lifecycle sequence
-     * @param event the event which should conclude notifications from the source
-     * @return a reusable {@link Observable.Transformer} that unsubscribes the source at the specified event
+     * Use {@link RxLifecycle#bindUntilEvent(Observable, Object)} instead, which does exactly the same thing.
      */
+    @Deprecated
     public static <T> Observable.Transformer<T, T> bindUntilFragmentEvent(
         final Observable<FragmentEvent> lifecycle, final FragmentEvent event) {
         return bindUntilEvent(lifecycle, event);
     }
 
     /**
-     * Binds the given source to an Activity lifecycle.
+     * Deprecated and will be removed in a future release.
+     *
+     * Use {@link RxLifecycle#bindUntilEvent(Observable, Object)} instead, which does exactly the same thing.
+     */
+    @Deprecated
+    public static <T> Observable.Transformer<T, T> bindUntilActivityEvent(
+        final Observable<ActivityEvent> lifecycle, final ActivityEvent event) {
+        return bindUntilEvent(lifecycle, event);
+    }
+
+    /**
+     * Binds the given source to a lifecycle.
      * <p>
      * When the lifecycle event occurs, the source will cease to emit any notifications.
      * <p>
      * Use with {@link Observable#compose(Observable.Transformer)}:
      * {@code source.compose(RxLifecycle.bindUntilEvent(lifecycle, ActivityEvent.STOP)).subscribe()}
      *
-     * @param lifecycle the Activity lifecycle sequence
+     * @param lifecycle the lifecycle sequence
      * @param event the event which should conclude notifications from the source
      * @return a reusable {@link Observable.Transformer} that unsubscribes the source at the specified event
      */
-    public static <T> Observable.Transformer<T, T> bindUntilActivityEvent(
-        final Observable<ActivityEvent> lifecycle, final ActivityEvent event) {
-        return bindUntilEvent(lifecycle, event);
-    }
-
-    private static <T, R> Observable.Transformer<T, T> bindUntilEvent(final Observable<R> lifecycle,
-                                                                      final R event) {
+    public static <T, R> Observable.Transformer<T, T> bindUntilEvent(final Observable<R> lifecycle,
+                                                                     final R event) {
         if (lifecycle == null) {
             throw new IllegalArgumentException("Lifecycle must be given");
         }

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle/RxLifecycleTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle/RxLifecycleTest.java
@@ -51,7 +51,7 @@ public class RxLifecycleTest {
         BehaviorSubject<FragmentEvent> lifecycle = BehaviorSubject.create();
         TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
 
-        observable.compose(RxLifecycle.bindUntilFragmentEvent(lifecycle, FragmentEvent.STOP))
+        observable.compose(RxLifecycle.bindUntilEvent(lifecycle, FragmentEvent.STOP))
             .subscribe(testSubscriber);
 
         lifecycle.onNext(FragmentEvent.ATTACH);
@@ -76,7 +76,7 @@ public class RxLifecycleTest {
         BehaviorSubject<ActivityEvent> lifecycle = BehaviorSubject.create();
         TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
 
-        observable.compose(RxLifecycle.bindUntilActivityEvent(lifecycle, ActivityEvent.STOP))
+        observable.compose(RxLifecycle.bindUntilEvent(lifecycle, ActivityEvent.STOP))
             .subscribe(testSubscriber);
 
         lifecycle.onNext(ActivityEvent.CREATE);
@@ -288,13 +288,13 @@ public class RxLifecycleTest {
 
     @Test(expected=IllegalArgumentException.class)
     public void testBindUntilFragmentEventThrowsOnNullLifecycle() {
-        RxLifecycle.bindUntilFragmentEvent(null, FragmentEvent.CREATE);
+        RxLifecycle.bindUntilEvent(null, FragmentEvent.CREATE);
     }
 
     @Test(expected=IllegalArgumentException.class)
     public void testBindUntilFragmentEventThrowsOnNullEvent() {
         BehaviorSubject<FragmentEvent> lifecycle = BehaviorSubject.create();
-        RxLifecycle.bindUntilFragmentEvent(lifecycle, null);
+        RxLifecycle.bindUntilEvent(lifecycle, null);
     }
 
     @Test(expected=IllegalArgumentException.class)
@@ -304,13 +304,13 @@ public class RxLifecycleTest {
 
     @Test(expected=IllegalArgumentException.class)
     public void testBindUntilActivityThrowsOnNullLifecycle() {
-        RxLifecycle.bindUntilActivityEvent(null, ActivityEvent.CREATE);
+        RxLifecycle.bindUntilEvent(null, ActivityEvent.CREATE);
     }
 
     @Test(expected=IllegalArgumentException.class)
     public void testBindUntilActivityEventThrowsOnNullEvent() {
         BehaviorSubject<ActivityEvent> lifecycle = BehaviorSubject.create();
-        RxLifecycle.bindUntilActivityEvent(lifecycle, null);
+        RxLifecycle.bindUntilEvent(lifecycle, null);
     }
 
     @Test(expected=IllegalArgumentException.class)


### PR DESCRIPTION
In hindsight, it was totally unnecessary to split them up, since the
type checker will prevent you from binding FragmentEvents to
ActivityEvent streams and vice versa.

Partially addresses #76