### PR TITLE
fix navi package

### DIFF
--- a/rxlifecycle-navi/src/main/AndroidManifest.xml
+++ b/rxlifecycle-navi/src/main/AndroidManifest.xml
@@ -10,4 +10,4 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<manifest package="com.trello.rxlifecycle.components" />
+<manifest package="com.trello.rxlifecycle.navi" />


### PR DESCRIPTION
This is done by mistake, right?

I understand that there is no point to use both navi and component bindings in same project, but i need to migrate, and it wouldn't be in a single commit.

So if one add both dependencies:

```
compile 'com.trello:rxlifecycle-components:0.5.0'
compile 'com.trello:rxlifecycle-navi:0.5.0'
```
it leads to
```
Error:Execution failed for task ':app:transformClassesWithDexForDebug'.
> com.android.build.api.transform.TransformException: com.android.ide.common.process.ProcessException: java.util.concurrent.ExecutionException: com.android.dex.DexException: Multiple dex files define Lcom/trello/rxlifecycle/components/BuildConfig;
```