### PR TITLE
Added support for Single

### DIFF
--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/LifecycleTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/LifecycleTransformer.java
@@ -1,0 +1,10 @@
+package com.trello.rxlifecycle;
+
+import rx.Observable;
+import rx.Single;
+
+public interface LifecycleTransformer<T> extends Observable.Transformer<T, T> {
+
+    Single.Transformer<T, T> forSingle();
+
+}

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/RxLifecycle.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/RxLifecycle.java
@@ -37,7 +37,7 @@ public class RxLifecycle {
     @Deprecated
     @NonNull
     @CheckResult
-    public static <T> Observable.Transformer<T, T> bindUntilFragmentEvent(
+    public static <T> LifecycleTransformer<T> bindUntilFragmentEvent(
         @NonNull final Observable<FragmentEvent> lifecycle, @NonNull final FragmentEvent event) {
         return bindUntilEvent(lifecycle, event);
     }
@@ -50,7 +50,7 @@ public class RxLifecycle {
     @Deprecated
     @NonNull
     @CheckResult
-    public static <T> Observable.Transformer<T, T> bindUntilActivityEvent(
+    public static <T> LifecycleTransformer<T> bindUntilActivityEvent(
         @NonNull final Observable<ActivityEvent> lifecycle, @NonNull final ActivityEvent event) {
         return bindUntilEvent(lifecycle, event);
     }
@@ -69,8 +69,8 @@ public class RxLifecycle {
      */
     @NonNull
     @CheckResult
-    public static <T, R> Observable.Transformer<T, T> bindUntilEvent(@NonNull final Observable<R> lifecycle,
-                                                                     @NonNull final R event) {
+    public static <T, R> LifecycleTransformer<T> bindUntilEvent(@NonNull final Observable<R> lifecycle,
+                                                                @NonNull final R event) {
         checkNotNull(lifecycle, "lifecycle == null");
         checkNotNull(event, "event == null");
 
@@ -97,7 +97,7 @@ public class RxLifecycle {
      */
     @NonNull
     @CheckResult
-    public static <T> Observable.Transformer<T, T> bindActivity(@NonNull final Observable<ActivityEvent> lifecycle) {
+    public static <T> LifecycleTransformer<T> bindActivity(@NonNull final Observable<ActivityEvent> lifecycle) {
         return bind(lifecycle, ACTIVITY_LIFECYCLE);
     }
 
@@ -121,7 +121,7 @@ public class RxLifecycle {
      */
     @NonNull
     @CheckResult
-    public static <T> Observable.Transformer<T, T> bindFragment(@NonNull final Observable<FragmentEvent> lifecycle) {
+    public static <T> LifecycleTransformer<T> bindFragment(@NonNull final Observable<FragmentEvent> lifecycle) {
         return bind(lifecycle, FRAGMENT_LIFECYCLE);
     }
 
@@ -141,7 +141,7 @@ public class RxLifecycle {
      */
     @NonNull
     @CheckResult
-    public static <T> Observable.Transformer<T, T> bindView(@NonNull final View view) {
+    public static <T> LifecycleTransformer<T> bindView(@NonNull final View view) {
         checkNotNull(view, "view == null");
 
         return bind(RxView.detaches(view));
@@ -155,7 +155,7 @@ public class RxLifecycle {
     @Deprecated
     @NonNull
     @CheckResult
-    public static <T, E> Observable.Transformer<T, T> bindView(@NonNull final Observable<? extends E> lifecycle) {
+    public static <T, E> LifecycleTransformer<T> bindView(@NonNull final Observable<? extends E> lifecycle) {
         return bind(lifecycle);
     }
 
@@ -174,7 +174,7 @@ public class RxLifecycle {
      */
     @NonNull
     @CheckResult
-    public static <T, R> Observable.Transformer<T, T> bind(@NonNull final Observable<R> lifecycle) {
+    public static <T, R> LifecycleTransformer<T> bind(@NonNull final Observable<R> lifecycle) {
         checkNotNull(lifecycle, "lifecycle == null");
 
         return new UntilLifecycleObservableTransformer<>(lifecycle);
@@ -196,13 +196,13 @@ public class RxLifecycle {
      */
     @NonNull
     @CheckResult
-    public static <T, R> Observable.Transformer<T, T> bind(@NonNull Observable<R> lifecycle,
-                                                           @NonNull final Func1<R, R> correspondingEvents) {
+    public static <T, R> LifecycleTransformer<T> bind(@NonNull Observable<R> lifecycle,
+                                                      @NonNull final Func1<R, R> correspondingEvents) {
         checkNotNull(lifecycle, "lifecycle == null");
         checkNotNull(correspondingEvents, "correspondingEvents == null");
 
         // Keep emitting from source until the corresponding event occurs in the lifecycle
-        return new UntilCorrespondingEventObservableTransformer<>(lifecycle, correspondingEvents);
+        return new UntilCorrespondingEventObservableTransformer<>(lifecycle.share(), correspondingEvents);
     }
 
     // Figures out which corresponding next lifecycle event in which to unsubscribe, for Activities

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/TakeUntilGenerator.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/TakeUntilGenerator.java
@@ -1,0 +1,62 @@
+package com.trello.rxlifecycle;
+
+import android.support.annotation.CheckResult;
+import android.support.annotation.NonNull;
+import rx.Observable;
+import rx.exceptions.Exceptions;
+import rx.functions.Func1;
+import rx.functions.Func2;
+
+final class TakeUntilGenerator {
+
+    @NonNull
+    @CheckResult
+    static <T> Observable<T> takeUntilEvent(@NonNull final Observable<T> lifecycle, @NonNull final T event) {
+        return lifecycle.takeFirst(new Func1<T, Boolean>() {
+            @Override
+            public Boolean call(T lifecycleEvent) {
+                return lifecycleEvent.equals(event);
+            }
+        });
+    }
+
+    @NonNull
+    @CheckResult
+    static <T> Observable<Boolean> takeUntilCorrespondingEvent(@NonNull final Observable<T> lifecycle,
+                                                               @NonNull final Func1<T, T> correspondingEvents) {
+        return Observable.combineLatest(
+            lifecycle.take(1).map(correspondingEvents),
+            lifecycle.skip(1),
+            new Func2<T, T, Boolean>() {
+                @Override
+                public Boolean call(T bindUntilEvent, T lifecycleEvent) {
+                    return lifecycleEvent.equals(bindUntilEvent);
+                }
+            })
+            .onErrorReturn(RESUME_FUNCTION)
+            .takeFirst(SHOULD_COMPLETE);
+    }
+
+    private static final Func1<Throwable, Boolean> RESUME_FUNCTION = new Func1<Throwable, Boolean>() {
+        @Override
+        public Boolean call(Throwable throwable) {
+            if (throwable instanceof OutsideLifecycleException) {
+                return true;
+            }
+
+            Exceptions.propagate(throwable);
+            return false;
+        }
+    };
+
+    private static final Func1<Boolean, Boolean> SHOULD_COMPLETE = new Func1<Boolean, Boolean>() {
+        @Override
+        public Boolean call(Boolean shouldComplete) {
+            return shouldComplete;
+        }
+    };
+
+    private TakeUntilGenerator() {
+        throw new AssertionError("No instances!");
+    }
+}

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilCorrespondingEventObservableTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilCorrespondingEventObservableTransformer.java
@@ -1,9 +1,9 @@
 package com.trello.rxlifecycle;
 
 import rx.Observable;
-import rx.exceptions.Exceptions;
 import rx.functions.Func1;
-import rx.functions.Func2;
+
+import static com.trello.rxlifecycle.TakeUntilGenerator.takeUntilCorrespondingEvent;
 
 /**
  * Continues a subscription until it sees a particular lifecycle event.
@@ -23,37 +23,6 @@ class UntilCorrespondingEventObservableTransformer<T, R> implements Observable.T
 
     @Override
     public Observable<T> call(Observable<T> source) {
-        return source.takeUntil(
-            Observable.combineLatest(
-                this.sharedLifecycle.take(1).map(correspondingEvents),
-                this.sharedLifecycle.skip(1),
-                new Func2<R, R, Boolean>() {
-                    @Override
-                    public Boolean call(R bindUntilEvent, R lifecycleEvent) {
-                        return lifecycleEvent.equals(bindUntilEvent);
-                    }
-                })
-                .onErrorReturn(RESUME_FUNCTION)
-                .takeFirst(SHOULD_COMPLETE)
-        );
+        return source.takeUntil(takeUntilCorrespondingEvent(sharedLifecycle, correspondingEvents));
     }
-
-    private static final Func1<Throwable, Boolean> RESUME_FUNCTION = new Func1<Throwable, Boolean>() {
-        @Override
-        public Boolean call(Throwable throwable) {
-            if (throwable instanceof OutsideLifecycleException) {
-                return true;
-            }
-
-            Exceptions.propagate(throwable);
-            return false;
-        }
-    };
-
-    private static final Func1<Boolean, Boolean> SHOULD_COMPLETE = new Func1<Boolean, Boolean>() {
-        @Override
-        public Boolean call(Boolean shouldComplete) {
-            return shouldComplete;
-        }
-    };
 }

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilCorrespondingEventObservableTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilCorrespondingEventObservableTransformer.java
@@ -1,6 +1,8 @@
 package com.trello.rxlifecycle;
 
+import android.support.annotation.NonNull;
 import rx.Observable;
+import rx.Single;
 import rx.functions.Func1;
 
 import static com.trello.rxlifecycle.TakeUntilGenerator.takeUntilCorrespondingEvent;
@@ -11,18 +13,51 @@ import static com.trello.rxlifecycle.TakeUntilGenerator.takeUntilCorrespondingEv
  * That lifecycle event is determined based on what stage we're at in
  * the current lifecycle.
  */
-class UntilCorrespondingEventObservableTransformer<T, R> implements Observable.Transformer<T, T> {
+final class UntilCorrespondingEventObservableTransformer<T, R> implements LifecycleTransformer<T> {
 
     final Observable<R> sharedLifecycle;
     final Func1<R, R> correspondingEvents;
 
-    public UntilCorrespondingEventObservableTransformer(Observable<R> lifecycle, Func1<R, R> correspondingEvents) {
-        this.sharedLifecycle = lifecycle.share(); // Share so that we always compare identical lifecycles
+    public UntilCorrespondingEventObservableTransformer(@NonNull Observable<R> sharedLifecycle,
+                                                        @NonNull Func1<R, R> correspondingEvents) {
+        this.sharedLifecycle = sharedLifecycle;
         this.correspondingEvents = correspondingEvents;
     }
 
     @Override
     public Observable<T> call(Observable<T> source) {
         return source.takeUntil(takeUntilCorrespondingEvent(sharedLifecycle, correspondingEvents));
+    }
+
+    @Override
+    public Single.Transformer<T, T> forSingle() {
+        return new UntilCorrespondingEventSingleTransformer<>(sharedLifecycle, correspondingEvents);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        UntilCorrespondingEventObservableTransformer<?, ?> that
+            = (UntilCorrespondingEventObservableTransformer<?, ?>) o;
+
+        if (!sharedLifecycle.equals(that.sharedLifecycle)) { return false; }
+        return correspondingEvents.equals(that.correspondingEvents);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = sharedLifecycle.hashCode();
+        result = 31 * result + correspondingEvents.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "UntilCorrespondingEventObservableTransformer{" +
+            "sharedLifecycle=" + sharedLifecycle +
+            ", correspondingEvents=" + correspondingEvents +
+            '}';
     }
 }

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilCorrespondingEventSingleTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilCorrespondingEventSingleTransformer.java
@@ -1,5 +1,6 @@
 package com.trello.rxlifecycle;
 
+import android.support.annotation.NonNull;
 import rx.Observable;
 import rx.Single;
 import rx.functions.Func1;
@@ -12,18 +13,45 @@ import static com.trello.rxlifecycle.TakeUntilGenerator.takeUntilCorrespondingEv
  * That lifecycle event is determined based on what stage we're at in
  * the current lifecycle.
  */
-class UntilCorrespondingEventSingleTransformer<T, R> implements Single.Transformer<T, T> {
+final class UntilCorrespondingEventSingleTransformer<T, R> implements Single.Transformer<T, T> {
 
     final Observable<R> sharedLifecycle;
     final Func1<R, R> correspondingEvents;
 
-    public UntilCorrespondingEventSingleTransformer(Observable<R> lifecycle, Func1<R, R> correspondingEvents) {
-        this.sharedLifecycle = lifecycle.share(); // Share so that we always compare identical lifecycles
+    public UntilCorrespondingEventSingleTransformer(@NonNull Observable<R> sharedLifecycle,
+                                                    @NonNull Func1<R, R> correspondingEvents) {
+        this.sharedLifecycle = sharedLifecycle;
         this.correspondingEvents = correspondingEvents;
     }
 
     @Override
     public Single<T> call(Single<T> source) {
         return source.takeUntil(takeUntilCorrespondingEvent(sharedLifecycle, correspondingEvents));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        UntilCorrespondingEventSingleTransformer<?, ?> that = (UntilCorrespondingEventSingleTransformer<?, ?>) o;
+
+        if (!sharedLifecycle.equals(that.sharedLifecycle)) { return false; }
+        return correspondingEvents.equals(that.correspondingEvents);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = sharedLifecycle.hashCode();
+        result = 31 * result + correspondingEvents.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "UntilCorrespondingEventSingleTransformer{" +
+            "sharedLifecycle=" + sharedLifecycle +
+            ", correspondingEvents=" + correspondingEvents +
+            '}';
     }
 }

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilCorrespondingEventSingleTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilCorrespondingEventSingleTransformer.java
@@ -1,0 +1,60 @@
+package com.trello.rxlifecycle;
+
+import rx.Observable;
+import rx.Single;
+import rx.exceptions.Exceptions;
+import rx.functions.Func1;
+import rx.functions.Func2;
+
+/**
+ * Continues a subscription until it sees a particular lifecycle event.
+ *
+ * That lifecycle event is determined based on what stage we're at in
+ * the current lifecycle.
+ */
+class UntilCorrespondingEventSingleTransformer<T, R> implements Single.Transformer<T, T> {
+
+    final Observable<R> sharedLifecycle;
+    final Func1<R, R> correspondingEvents;
+
+    public UntilCorrespondingEventSingleTransformer(Observable<R> lifecycle, Func1<R, R> correspondingEvents) {
+        this.sharedLifecycle = lifecycle.share(); // Share so that we always compare identical lifecycles
+        this.correspondingEvents = correspondingEvents;
+    }
+
+    @Override
+    public Single<T> call(Single<T> source) {
+        return source.takeUntil(
+            Observable.combineLatest(
+                this.sharedLifecycle.take(1).map(correspondingEvents),
+                this.sharedLifecycle.skip(1),
+                new Func2<R, R, Boolean>() {
+                    @Override
+                    public Boolean call(R bindUntilEvent, R lifecycleEvent) {
+                        return lifecycleEvent.equals(bindUntilEvent);
+                    }
+                })
+                .onErrorReturn(RESUME_FUNCTION)
+                .takeFirst(SHOULD_COMPLETE)
+        );
+    }
+
+    private static final Func1<Throwable, Boolean> RESUME_FUNCTION = new Func1<Throwable, Boolean>() {
+        @Override
+        public Boolean call(Throwable throwable) {
+            if (throwable instanceof OutsideLifecycleException) {
+                return true;
+            }
+
+            Exceptions.propagate(throwable);
+            return false;
+        }
+    };
+
+    private static final Func1<Boolean, Boolean> SHOULD_COMPLETE = new Func1<Boolean, Boolean>() {
+        @Override
+        public Boolean call(Boolean shouldComplete) {
+            return shouldComplete;
+        }
+    };
+}

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilCorrespondingEventSingleTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilCorrespondingEventSingleTransformer.java
@@ -2,9 +2,9 @@ package com.trello.rxlifecycle;
 
 import rx.Observable;
 import rx.Single;
-import rx.exceptions.Exceptions;
 import rx.functions.Func1;
-import rx.functions.Func2;
+
+import static com.trello.rxlifecycle.TakeUntilGenerator.takeUntilCorrespondingEvent;
 
 /**
  * Continues a subscription until it sees a particular lifecycle event.
@@ -24,37 +24,6 @@ class UntilCorrespondingEventSingleTransformer<T, R> implements Single.Transform
 
     @Override
     public Single<T> call(Single<T> source) {
-        return source.takeUntil(
-            Observable.combineLatest(
-                this.sharedLifecycle.take(1).map(correspondingEvents),
-                this.sharedLifecycle.skip(1),
-                new Func2<R, R, Boolean>() {
-                    @Override
-                    public Boolean call(R bindUntilEvent, R lifecycleEvent) {
-                        return lifecycleEvent.equals(bindUntilEvent);
-                    }
-                })
-                .onErrorReturn(RESUME_FUNCTION)
-                .takeFirst(SHOULD_COMPLETE)
-        );
+        return source.takeUntil(takeUntilCorrespondingEvent(sharedLifecycle, correspondingEvents));
     }
-
-    private static final Func1<Throwable, Boolean> RESUME_FUNCTION = new Func1<Throwable, Boolean>() {
-        @Override
-        public Boolean call(Throwable throwable) {
-            if (throwable instanceof OutsideLifecycleException) {
-                return true;
-            }
-
-            Exceptions.propagate(throwable);
-            return false;
-        }
-    };
-
-    private static final Func1<Boolean, Boolean> SHOULD_COMPLETE = new Func1<Boolean, Boolean>() {
-        @Override
-        public Boolean call(Boolean shouldComplete) {
-            return shouldComplete;
-        }
-    };
 }

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilEventObservableTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilEventObservableTransformer.java
@@ -1,7 +1,8 @@
 package com.trello.rxlifecycle;
 
 import rx.Observable;
-import rx.functions.Func1;
+
+import static com.trello.rxlifecycle.TakeUntilGenerator.takeUntilEvent;
 
 /**
  * Continues a subscription until it sees a particular lifecycle event.
@@ -18,13 +19,6 @@ class UntilEventObservableTransformer<T, R> implements Observable.Transformer<T,
 
     @Override
     public Observable<T> call(Observable<T> source) {
-        return source.takeUntil(
-            lifecycle.takeFirst(new Func1<R, Boolean>() {
-                @Override
-                public Boolean call(R lifecycleEvent) {
-                    return lifecycleEvent.equals(event);
-                }
-            })
-        );
+        return source.takeUntil(takeUntilEvent(lifecycle, event));
     }
 }

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilEventObservableTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilEventObservableTransformer.java
@@ -1,18 +1,20 @@
 package com.trello.rxlifecycle;
 
+import android.support.annotation.NonNull;
 import rx.Observable;
+import rx.Single;
 
 import static com.trello.rxlifecycle.TakeUntilGenerator.takeUntilEvent;
 
 /**
  * Continues a subscription until it sees a particular lifecycle event.
  */
-class UntilEventObservableTransformer<T, R> implements Observable.Transformer<T, T> {
+final class UntilEventObservableTransformer<T, R> implements LifecycleTransformer<T> {
 
     final Observable<R> lifecycle;
     final R event;
 
-    public UntilEventObservableTransformer(Observable<R> lifecycle, R event) {
+    public UntilEventObservableTransformer(@NonNull Observable<R> lifecycle, @NonNull R event) {
         this.lifecycle = lifecycle;
         this.event = event;
     }
@@ -20,5 +22,36 @@ class UntilEventObservableTransformer<T, R> implements Observable.Transformer<T,
     @Override
     public Observable<T> call(Observable<T> source) {
         return source.takeUntil(takeUntilEvent(lifecycle, event));
+    }
+
+    @Override
+    public Single.Transformer<T, T> forSingle() {
+        return new UntilEventSingleTransformer<>(lifecycle, event);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        UntilEventObservableTransformer<?, ?> that = (UntilEventObservableTransformer<?, ?>) o;
+
+        if (!lifecycle.equals(that.lifecycle)) { return false; }
+        return event.equals(that.event);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = lifecycle.hashCode();
+        result = 31 * result + event.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "UntilEventObservableTransformer{" +
+            "lifecycle=" + lifecycle +
+            ", event=" + event +
+            '}';
     }
 }

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilEventSingleTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilEventSingleTransformer.java
@@ -2,7 +2,8 @@ package com.trello.rxlifecycle;
 
 import rx.Observable;
 import rx.Single;
-import rx.functions.Func1;
+
+import static com.trello.rxlifecycle.TakeUntilGenerator.takeUntilEvent;
 
 /**
  * Continues a subscription until it sees a particular lifecycle event.
@@ -19,13 +20,6 @@ class UntilEventSingleTransformer<T, R> implements Single.Transformer<T, T> {
 
     @Override
     public Single<T> call(Single<T> source) {
-        return source.takeUntil(
-            lifecycle.takeFirst(new Func1<R, Boolean>() {
-                @Override
-                public Boolean call(R lifecycleEvent) {
-                    return lifecycleEvent.equals(event);
-                }
-            })
-        );
+        return source.takeUntil(takeUntilEvent(lifecycle, event));
     }
 }

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilEventSingleTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilEventSingleTransformer.java
@@ -1,5 +1,6 @@
 package com.trello.rxlifecycle;
 
+import android.support.annotation.NonNull;
 import rx.Observable;
 import rx.Single;
 
@@ -8,12 +9,12 @@ import static com.trello.rxlifecycle.TakeUntilGenerator.takeUntilEvent;
 /**
  * Continues a subscription until it sees a particular lifecycle event.
  */
-class UntilEventSingleTransformer<T, R> implements Single.Transformer<T, T> {
+final class UntilEventSingleTransformer<T, R> implements Single.Transformer<T, T> {
 
     final Observable<R> lifecycle;
     final R event;
 
-    public UntilEventSingleTransformer(Observable<R> lifecycle, R event) {
+    public UntilEventSingleTransformer(@NonNull Observable<R> lifecycle, @NonNull R event) {
         this.lifecycle = lifecycle;
         this.event = event;
     }
@@ -21,5 +22,31 @@ class UntilEventSingleTransformer<T, R> implements Single.Transformer<T, T> {
     @Override
     public Single<T> call(Single<T> source) {
         return source.takeUntil(takeUntilEvent(lifecycle, event));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        UntilEventSingleTransformer<?, ?> that = (UntilEventSingleTransformer<?, ?>) o;
+
+        if (!lifecycle.equals(that.lifecycle)) { return false; }
+        return event.equals(that.event);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = lifecycle.hashCode();
+        result = 31 * result + event.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "UntilEventSingleTransformer{" +
+            "lifecycle=" + lifecycle +
+            ", event=" + event +
+            '}';
     }
 }

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilEventSingleTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilEventSingleTransformer.java
@@ -1,0 +1,31 @@
+package com.trello.rxlifecycle;
+
+import rx.Observable;
+import rx.Single;
+import rx.functions.Func1;
+
+/**
+ * Continues a subscription until it sees a particular lifecycle event.
+ */
+class UntilEventSingleTransformer<T, R> implements Single.Transformer<T, T> {
+
+    final Observable<R> lifecycle;
+    final R event;
+
+    public UntilEventSingleTransformer(Observable<R> lifecycle, R event) {
+        this.lifecycle = lifecycle;
+        this.event = event;
+    }
+
+    @Override
+    public Single<T> call(Single<T> source) {
+        return source.takeUntil(
+            lifecycle.takeFirst(new Func1<R, Boolean>() {
+                @Override
+                public Boolean call(R lifecycleEvent) {
+                    return lifecycleEvent.equals(event);
+                }
+            })
+        );
+    }
+}

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilLifecycleObservableTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilLifecycleObservableTransformer.java
@@ -1,20 +1,49 @@
 package com.trello.rxlifecycle;
 
+import android.support.annotation.NonNull;
 import rx.Observable;
+import rx.Single;
 
 /**
  * Continues a subscription until it sees *any* lifecycle event.
  */
-class UntilLifecycleObservableTransformer<T, R> implements Observable.Transformer<T, T> {
+final class UntilLifecycleObservableTransformer<T, R> implements LifecycleTransformer<T> {
 
     final Observable<R> lifecycle;
 
-    public UntilLifecycleObservableTransformer(Observable<R> lifecycle) {
+    public UntilLifecycleObservableTransformer(@NonNull Observable<R> lifecycle) {
         this.lifecycle = lifecycle;
     }
 
     @Override
     public Observable<T> call(Observable<T> source) {
         return source.takeUntil(lifecycle);
+    }
+
+    @Override
+    public Single.Transformer<T, T> forSingle() {
+        return new UntilLifecycleSingleTransformer<>(lifecycle);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        UntilLifecycleObservableTransformer<?, ?> that = (UntilLifecycleObservableTransformer<?, ?>) o;
+
+        return lifecycle.equals(that.lifecycle);
+    }
+
+    @Override
+    public int hashCode() {
+        return lifecycle.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "UntilLifecycleObservableTransformer{" +
+            "lifecycle=" + lifecycle +
+            '}';
     }
 }

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilLifecycleSingleTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilLifecycleSingleTransformer.java
@@ -1,0 +1,21 @@
+package com.trello.rxlifecycle;
+
+import rx.Observable;
+import rx.Single;
+
+/**
+ * Continues a subscription until it sees *any* lifecycle event.
+ */
+class UntilLifecycleSingleTransformer<T, R> implements Single.Transformer<T, T> {
+
+    final Observable<R> lifecycle;
+
+    public UntilLifecycleSingleTransformer(Observable<R> lifecycle) {
+        this.lifecycle = lifecycle;
+    }
+
+    @Override
+    public Single<T> call(Single<T> source) {
+        return source.takeUntil(lifecycle);
+    }
+}

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilLifecycleSingleTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilLifecycleSingleTransformer.java
@@ -1,21 +1,44 @@
 package com.trello.rxlifecycle;
 
+import android.support.annotation.NonNull;
 import rx.Observable;
 import rx.Single;
 
 /**
  * Continues a subscription until it sees *any* lifecycle event.
  */
-class UntilLifecycleSingleTransformer<T, R> implements Single.Transformer<T, T> {
+final class UntilLifecycleSingleTransformer<T, R> implements Single.Transformer<T, T> {
 
     final Observable<R> lifecycle;
 
-    public UntilLifecycleSingleTransformer(Observable<R> lifecycle) {
+    public UntilLifecycleSingleTransformer(@NonNull Observable<R> lifecycle) {
         this.lifecycle = lifecycle;
     }
 
     @Override
     public Single<T> call(Single<T> source) {
         return source.takeUntil(lifecycle);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        UntilLifecycleSingleTransformer<?, ?> that = (UntilLifecycleSingleTransformer<?, ?>) o;
+
+        return lifecycle.equals(that.lifecycle);
+    }
+
+    @Override
+    public int hashCode() {
+        return lifecycle.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "UntilLifecycleSingleTransformer{" +
+            "lifecycle=" + lifecycle +
+            '}';
     }
 }

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle/LifecycleTransformerTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle/LifecycleTransformerTest.java
@@ -1,0 +1,56 @@
+package com.trello.rxlifecycle;
+
+import org.junit.Test;
+import rx.Observable;
+import rx.functions.Func1;
+
+import static org.junit.Assert.*;
+
+public class LifecycleTransformerTest {
+
+    Observable<String> lifecycle = Observable.never();
+
+    @Test
+    public void correspondingEventObservableConversionEqualsSingle() {
+        UntilCorrespondingEventObservableTransformer<String, String> observableTransformer =
+            new UntilCorrespondingEventObservableTransformer<>(lifecycle, CORRESPONDING_EVENTS);
+
+        UntilCorrespondingEventSingleTransformer<String, String> singleTransformer =
+            new UntilCorrespondingEventSingleTransformer<>(lifecycle, CORRESPONDING_EVENTS);
+
+        assertEquals(singleTransformer, observableTransformer.forSingle());
+    }
+
+    @Test
+    public void untilEventObservableConversionEqualsSingle() {
+        UntilEventObservableTransformer<String, String> observableTransformer =
+            new UntilEventObservableTransformer<>(lifecycle, "stop");
+
+        UntilEventSingleTransformer<String, String> singleTransformer =
+            new UntilEventSingleTransformer<>(lifecycle, "stop");
+
+        assertEquals(singleTransformer, observableTransformer.forSingle());
+    }
+
+    @Test
+    public void untilLifecycleObservableConversionEqualsSingle() {
+        UntilLifecycleObservableTransformer<String, String> observableTransformer =
+            new UntilLifecycleObservableTransformer<>(lifecycle);
+
+        UntilLifecycleSingleTransformer<String, String> singleTransformer =
+            new UntilLifecycleSingleTransformer<>(lifecycle);
+
+        assertEquals(singleTransformer, observableTransformer.forSingle());
+    }
+
+    private static final Func1<String, String> CORRESPONDING_EVENTS = new Func1<String, String>() {
+        @Override
+        public String call(String s) {
+            if (s.equals("create")) {
+                return "destroy";
+            }
+
+            throw new IllegalArgumentException("Cannot handle: " + s);
+        }
+    };
+}

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilCorrespondingEventSingleTransformerTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilCorrespondingEventSingleTransformerTest.java
@@ -1,0 +1,82 @@
+package com.trello.rxlifecycle;
+
+import org.junit.Before;
+import org.junit.Test;
+import rx.Single;
+import rx.functions.Func1;
+import rx.observers.TestSubscriber;
+import rx.subjects.PublishSubject;
+
+import java.util.concurrent.CancellationException;
+
+public class UntilCorrespondingEventSingleTransformerTest {
+
+    PublishSubject<String> lifecycle;
+    TestSubscriber<String> testSubscriber;
+
+    @Before
+    public void setup() {
+        lifecycle = PublishSubject.create();
+        testSubscriber = new TestSubscriber<>(0);
+    }
+
+    @Test
+    public void noEvents() {
+        Single.just("1")
+            .compose(new UntilCorrespondingEventSingleTransformer<String, String>(lifecycle, CORRESPONDING_EVENTS))
+            .subscribe(testSubscriber);
+
+        testSubscriber.requestMore(1);
+        testSubscriber.assertValue("1");
+        testSubscriber.assertCompleted();
+    }
+
+    @Test
+    public void oneStartEvent() {
+        Single.just("1")
+            .compose(new UntilCorrespondingEventSingleTransformer<String, String>(lifecycle, CORRESPONDING_EVENTS))
+            .subscribe(testSubscriber);
+
+        lifecycle.onNext("create");
+        testSubscriber.requestMore(1);
+        testSubscriber.assertValue("1");
+        testSubscriber.assertCompleted();
+    }
+
+    @Test
+    public void twoOpenEvents() {
+        Single.just("1")
+            .compose(new UntilCorrespondingEventSingleTransformer<String, String>(lifecycle, CORRESPONDING_EVENTS))
+            .subscribe(testSubscriber);
+
+        lifecycle.onNext("create");
+        lifecycle.onNext("start");
+        testSubscriber.requestMore(1);
+        testSubscriber.assertValue("1");
+        testSubscriber.assertCompleted();
+    }
+
+    @Test
+    public void openAndCloseEvent() {
+        Single.just("1")
+            .compose(new UntilCorrespondingEventSingleTransformer<String, String>(lifecycle, CORRESPONDING_EVENTS))
+            .subscribe(testSubscriber);
+
+        lifecycle.onNext("create");
+        lifecycle.onNext("destroy");
+        testSubscriber.requestMore(1);
+        testSubscriber.assertNoValues();
+        testSubscriber.assertError(CancellationException.class);
+    }
+
+    private static final Func1<String, String> CORRESPONDING_EVENTS = new Func1<String, String>() {
+        @Override
+        public String call(String s) {
+            if (s.equals("create")) {
+                return "destroy";
+            }
+
+            throw new IllegalArgumentException("Cannot handle: " + s);
+        }
+    };
+}

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilEventObservableTransformerTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilEventObservableTransformerTest.java
@@ -2,44 +2,41 @@ package com.trello.rxlifecycle;
 
 import org.junit.Before;
 import org.junit.Test;
+import rx.Observable;
 import rx.observers.TestSubscriber;
 import rx.subjects.PublishSubject;
 
 public class UntilEventObservableTransformerTest {
 
-    PublishSubject<String> observable;
     PublishSubject<String> lifecycle;
     TestSubscriber<String> testSubscriber;
 
     @Before
     public void setup() {
-        observable = PublishSubject.create();
         lifecycle = PublishSubject.create();
-        testSubscriber = new TestSubscriber<>();
+        testSubscriber = new TestSubscriber<>(0);
     }
 
     @Test
     public void noEvents() {
-        observable
+        Observable.just("1", "2", "3")
             .compose(new UntilEventObservableTransformer<String, String>(lifecycle, "stop"))
             .subscribe(testSubscriber);
 
-        observable.onNext("1");
-        observable.onNext("2");
-
+        testSubscriber.requestMore(2);
         testSubscriber.assertValues("1", "2");
         testSubscriber.assertNoTerminalEvent();
     }
 
     @Test
     public void oneWrongEvent() {
-        observable
+        Observable.just("1", "2", "3")
             .compose(new UntilEventObservableTransformer<String, String>(lifecycle, "stop"))
             .subscribe(testSubscriber);
 
-        observable.onNext("1");
+        testSubscriber.requestMore(1);
         lifecycle.onNext("keep going");
-        observable.onNext("2");
+        testSubscriber.requestMore(1);
 
         testSubscriber.assertValues("1", "2");
         testSubscriber.assertNoTerminalEvent();
@@ -47,15 +44,15 @@ public class UntilEventObservableTransformerTest {
 
     @Test
     public void twoEvents() {
-        observable
+        Observable.just("1", "2", "3")
             .compose(new UntilEventObservableTransformer<String, String>(lifecycle, "stop"))
             .subscribe(testSubscriber);
 
-        observable.onNext("1");
+        testSubscriber.requestMore(1);
         lifecycle.onNext("keep going");
-        observable.onNext("2");
+        testSubscriber.requestMore(1);
         lifecycle.onNext("stop");
-        observable.onNext("3");
+        testSubscriber.requestMore(1);
 
         testSubscriber.assertValues("1", "2");
         testSubscriber.assertCompleted();

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilEventSingleTransformerTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilEventSingleTransformerTest.java
@@ -1,0 +1,60 @@
+package com.trello.rxlifecycle;
+
+import org.junit.Before;
+import org.junit.Test;
+import rx.Single;
+import rx.observers.TestSubscriber;
+import rx.subjects.PublishSubject;
+
+import java.util.concurrent.CancellationException;
+
+public class UntilEventSingleTransformerTest {
+
+    PublishSubject<String> lifecycle;
+    TestSubscriber<String> testSubscriber;
+
+    @Before
+    public void setup() {
+        lifecycle = PublishSubject.create();
+        testSubscriber = new TestSubscriber<>(0);
+    }
+
+    @Test
+    public void noEvents() {
+        Single.just("1")
+            .compose(new UntilEventSingleTransformer<String, String>(lifecycle, "stop"))
+            .subscribe(testSubscriber);
+
+        testSubscriber.requestMore(1);
+        testSubscriber.assertValue("1");
+        testSubscriber.assertCompleted();
+    }
+
+    @Test
+    public void oneWrongEvent() {
+        Single.just("1")
+            .compose(new UntilEventSingleTransformer<String, String>(lifecycle, "stop"))
+            .subscribe(testSubscriber);
+
+        lifecycle.onNext("keep going");
+        testSubscriber.requestMore(1);
+
+        testSubscriber.assertValue("1");
+        testSubscriber.assertCompleted();
+    }
+
+    @Test
+    public void twoEvents() {
+        Single.just("1")
+            .compose(new UntilEventSingleTransformer<String, String>(lifecycle, "stop"))
+            .subscribe(testSubscriber);
+
+        lifecycle.onNext("keep going");
+        lifecycle.onNext("stop");
+        testSubscriber.requestMore(1);
+
+        testSubscriber.assertNoValues();
+        testSubscriber.assertError(CancellationException.class);
+    }
+
+}

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilLifecycleObservableTransformerTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilLifecycleObservableTransformerTest.java
@@ -2,44 +2,41 @@ package com.trello.rxlifecycle;
 
 import org.junit.Before;
 import org.junit.Test;
+import rx.Observable;
 import rx.observers.TestSubscriber;
 import rx.subjects.PublishSubject;
 
 public class UntilLifecycleObservableTransformerTest {
 
-    PublishSubject<String> observable;
     PublishSubject<String> lifecycle;
     TestSubscriber<String> testSubscriber;
 
     @Before
     public void setup() {
-        observable = PublishSubject.create();
         lifecycle = PublishSubject.create();
-        testSubscriber = new TestSubscriber<>();
+        testSubscriber = new TestSubscriber<>(0);
     }
 
     @Test
     public void noEvent() {
-        observable
+        Observable.just("1", "2", "3")
             .compose(new UntilLifecycleObservableTransformer<String, String>(lifecycle))
             .subscribe(testSubscriber);
 
-        observable.onNext("1");
-        observable.onNext("2");
-
+        testSubscriber.requestMore(2);
         testSubscriber.assertValues("1", "2");
         testSubscriber.assertNoTerminalEvent();
     }
 
     @Test
     public void oneEvent() {
-        observable
+        Observable.just("1", "2", "3")
             .compose(new UntilLifecycleObservableTransformer<String, String>(lifecycle))
             .subscribe(testSubscriber);
 
-        observable.onNext("1");
+        testSubscriber.requestMore(1);
         lifecycle.onNext("stop");
-        observable.onNext("2");
+        testSubscriber.requestMore(1);
 
         testSubscriber.assertValues("1");
         testSubscriber.assertCompleted();

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilLifecycleSingleTransformerTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilLifecycleSingleTransformerTest.java
@@ -1,0 +1,45 @@
+package com.trello.rxlifecycle;
+
+import org.junit.Before;
+import org.junit.Test;
+import rx.Single;
+import rx.observers.TestSubscriber;
+import rx.subjects.PublishSubject;
+
+import java.util.concurrent.CancellationException;
+
+public class UntilLifecycleSingleTransformerTest {
+
+    PublishSubject<String> lifecycle;
+    TestSubscriber<String> testSubscriber;
+
+    @Before
+    public void setup() {
+        lifecycle = PublishSubject.create();
+        testSubscriber = new TestSubscriber<>(0);
+    }
+
+    @Test
+    public void noEvent() {
+        Single.just("1")
+            .compose(new UntilLifecycleSingleTransformer<String, String>(lifecycle))
+            .subscribe(testSubscriber);
+
+        testSubscriber.requestMore(1);
+        testSubscriber.assertValue("1");
+        testSubscriber.assertCompleted();
+    }
+
+    @Test
+    public void oneEvent() {
+        Single.just("1")
+            .compose(new UntilLifecycleSingleTransformer<String, String>(lifecycle))
+            .subscribe(testSubscriber);
+
+        lifecycle.onNext("stop");
+        testSubscriber.requestMore(1);
+
+        testSubscriber.assertNoValues();
+        testSubscriber.assertError(CancellationException.class);
+    }
+}


### PR DESCRIPTION
Via `LifecycleTransformer`, which allows us to keep the baseline support for `Observable.Transformer` but also a simple way to turn it into a `Single.Transformer`.

Fixes #39 