### PR TITLE
Check lifecycle start when mapping corresponding events

### DIFF
--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilEventObservableTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilEventObservableTransformer.java
@@ -25,11 +25,13 @@ final class UntilEventObservableTransformer<T, R> implements LifecycleTransforme
         return source.takeUntil(takeUntilEvent(lifecycle, event));
     }
 
+    @NonNull
     @Override
     public Single.Transformer<T, T> forSingle() {
         return new UntilEventSingleTransformer<>(lifecycle, event);
     }
 
+    @NonNull
     @Override
     public Completable.CompletableTransformer forCompletable() {
         return new UntilEventCompletableTransformer<>(lifecycle, event);

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilLifecycleObservableTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilLifecycleObservableTransformer.java
@@ -21,11 +21,13 @@ final class UntilLifecycleObservableTransformer<T, R> implements LifecycleTransf
         return source.takeUntil(lifecycle);
     }
 
+    @NonNull
     @Override
     public Single.Transformer<T, T> forSingle() {
         return new UntilLifecycleSingleTransformer<>(lifecycle);
     }
 
+    @NonNull
     @Override
     public Completable.CompletableTransformer forCompletable() {
         return new UntilLifecycleCompletableTransformer<>(lifecycle);


### PR DESCRIPTION
This would throw an error if there hasn't been a lifecycle event yet. Still a couple failing tests that probably just need to be tweaked, but wanted to put this up for discussion. Slight behavior change, but I'd argue that the behavior is better defined this way.