### PR TITLE
Subscriptions using bindToLifecycle during onCreateView should unsubscribe in onDestroyView and not in onDestroy

### DIFF
--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxDialogFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxDialogFragment.java
@@ -6,7 +6,10 @@ import android.support.annotation.CallSuper;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
+
 import com.trello.rxlifecycle.FragmentEvent;
 import com.trello.rxlifecycle.FragmentLifecycleProvider;
 import com.trello.rxlifecycle.LifecycleTransformer;
@@ -53,11 +56,13 @@ public class RxDialogFragment extends DialogFragment implements FragmentLifecycl
         lifecycleSubject.onNext(FragmentEvent.CREATE);
     }
 
+    @Nullable
     @Override
     @CallSuper
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = super.onCreateView(inflater, container, savedInstanceState);
         lifecycleSubject.onNext(FragmentEvent.CREATE_VIEW);
+        return view;
     }
 
     @Override

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxFragment.java
@@ -6,7 +6,10 @@ import android.support.annotation.CallSuper;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
+
 import com.trello.rxlifecycle.FragmentEvent;
 import com.trello.rxlifecycle.FragmentLifecycleProvider;
 import com.trello.rxlifecycle.LifecycleTransformer;
@@ -53,11 +56,13 @@ public class RxFragment extends Fragment implements FragmentLifecycleProvider {
         lifecycleSubject.onNext(FragmentEvent.CREATE);
     }
 
+    @Nullable
     @Override
     @CallSuper
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = super.onCreateView(inflater, container, savedInstanceState);
         lifecycleSubject.onNext(FragmentEvent.CREATE_VIEW);
+        return view;
     }
 
     @Override

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxDialogFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxDialogFragment.java
@@ -6,7 +6,10 @@ import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
+
 import com.trello.rxlifecycle.FragmentEvent;
 import com.trello.rxlifecycle.FragmentLifecycleProvider;
 import com.trello.rxlifecycle.LifecycleTransformer;
@@ -53,11 +56,13 @@ public class RxDialogFragment extends DialogFragment implements FragmentLifecycl
         lifecycleSubject.onNext(FragmentEvent.CREATE);
     }
 
+    @Nullable
     @Override
     @CallSuper
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View view = super.onCreateView(inflater, container, savedInstanceState);
         lifecycleSubject.onNext(FragmentEvent.CREATE_VIEW);
+        return view;
     }
 
     @Override

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragment.java
@@ -5,7 +5,10 @@ import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
+
 import com.trello.rxlifecycle.FragmentEvent;
 import com.trello.rxlifecycle.FragmentLifecycleProvider;
 import com.trello.rxlifecycle.LifecycleTransformer;
@@ -50,10 +53,12 @@ public class RxFragment extends Fragment implements FragmentLifecycleProvider {
         lifecycleSubject.onNext(FragmentEvent.CREATE);
     }
 
+    @Nullable
     @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View view = super.onCreateView(inflater, container, savedInstanceState);
         lifecycleSubject.onNext(FragmentEvent.CREATE_VIEW);
+        return view;
     }
 
     @Override

--- a/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/RxFragmentLifecycleTest.java
+++ b/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/RxFragmentLifecycleTest.java
@@ -63,7 +63,7 @@ public class RxFragmentLifecycleTest {
 
         fragment.onAttach(null);
         fragment.onCreate(null);
-        fragment.onViewCreated(null, null);
+        fragment.onCreateView(null, null, null);
         fragment.onStart();
         fragment.onResume();
         fragment.onPause();
@@ -125,16 +125,24 @@ public class RxFragmentLifecycleTest {
         TestSubscriber<Object> createTestSub = new TestSubscriber<>();
         observable.compose(provider.bindToLifecycle()).subscribe(createTestSub);
 
-        fragment.onViewCreated(null, null);
+        fragment.onCreateView(null, null, null);
         assertFalse(attachTestSub.isUnsubscribed());
         assertFalse(createTestSub.isUnsubscribed());
         TestSubscriber<Object> createViewTestSub = new TestSubscriber<>();
         observable.compose(provider.bindToLifecycle()).subscribe(createViewTestSub);
 
+        fragment.onViewCreated(null, null);
+        assertFalse(attachTestSub.isUnsubscribed());
+        assertFalse(createTestSub.isUnsubscribed());
+        assertFalse(createViewTestSub.isUnsubscribed());
+        TestSubscriber<Object> viewCreatedTestSub = new TestSubscriber<>();
+        observable.compose(provider.bindToLifecycle()).subscribe(viewCreatedTestSub);
+
         fragment.onStart();
         assertFalse(attachTestSub.isUnsubscribed());
         assertFalse(createTestSub.isUnsubscribed());
         assertFalse(createViewTestSub.isUnsubscribed());
+        assertFalse(viewCreatedTestSub.isUnsubscribed());
         TestSubscriber<Object> startTestSub = new TestSubscriber<>();
         observable.compose(provider.bindToLifecycle()).subscribe(startTestSub);
 
@@ -142,6 +150,7 @@ public class RxFragmentLifecycleTest {
         assertFalse(attachTestSub.isUnsubscribed());
         assertFalse(createTestSub.isUnsubscribed());
         assertFalse(createViewTestSub.isUnsubscribed());
+        assertFalse(viewCreatedTestSub.isUnsubscribed());
         assertFalse(startTestSub.isUnsubscribed());
         TestSubscriber<Object> resumeTestSub = new TestSubscriber<>();
         observable.compose(provider.bindToLifecycle()).subscribe(resumeTestSub);
@@ -150,6 +159,7 @@ public class RxFragmentLifecycleTest {
         assertFalse(attachTestSub.isUnsubscribed());
         assertFalse(createTestSub.isUnsubscribed());
         assertFalse(createViewTestSub.isUnsubscribed());
+        assertFalse(viewCreatedTestSub.isUnsubscribed());
         assertFalse(startTestSub.isUnsubscribed());
         resumeTestSub.assertCompleted();
         resumeTestSub.assertUnsubscribed();
@@ -160,6 +170,7 @@ public class RxFragmentLifecycleTest {
         assertFalse(attachTestSub.isUnsubscribed());
         assertFalse(createTestSub.isUnsubscribed());
         assertFalse(createViewTestSub.isUnsubscribed());
+        assertFalse(viewCreatedTestSub.isUnsubscribed());
         startTestSub.assertCompleted();
         startTestSub.assertUnsubscribed();
         pauseTestSub.assertCompleted();
@@ -172,6 +183,8 @@ public class RxFragmentLifecycleTest {
         assertFalse(createTestSub.isUnsubscribed());
         createViewTestSub.assertCompleted();
         createViewTestSub.assertUnsubscribed();
+        viewCreatedTestSub.assertCompleted();
+        viewCreatedTestSub.assertUnsubscribed();
         stopTestSub.assertCompleted();
         stopTestSub.assertUnsubscribed();
         TestSubscriber<Object> destroyViewTestSub = new TestSubscriber<>();

--- a/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/support/RxSupportFragmentLifecycleTest.java
+++ b/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/support/RxSupportFragmentLifecycleTest.java
@@ -74,7 +74,7 @@ public class RxSupportFragmentLifecycleTest {
 
         fragment.onAttach(null);
         fragment.onCreate(null);
-        fragment.onViewCreated(null, null);
+        fragment.onCreateView(null, null, null);
         fragment.onStart();
         fragment.onResume();
         fragment.onPause();
@@ -109,7 +109,7 @@ public class RxSupportFragmentLifecycleTest {
         assertFalse(testSubscriber.isUnsubscribed());
         fragment.onCreate(null);
         assertFalse(testSubscriber.isUnsubscribed());
-        fragment.onViewCreated(null, null);
+        fragment.onCreateView(null, null, null);
         assertFalse(testSubscriber.isUnsubscribed());
         fragment.onStart();
         assertFalse(testSubscriber.isUnsubscribed());
@@ -136,16 +136,24 @@ public class RxSupportFragmentLifecycleTest {
         TestSubscriber<Object> createTestSub = new TestSubscriber<>();
         observable.compose(provider.bindToLifecycle()).subscribe(createTestSub);
 
-        fragment.onViewCreated(null, null);
+        fragment.onCreateView(null, null, null);
         assertFalse(attachTestSub.isUnsubscribed());
         assertFalse(createTestSub.isUnsubscribed());
         TestSubscriber<Object> createViewTestSub = new TestSubscriber<>();
         observable.compose(provider.bindToLifecycle()).subscribe(createViewTestSub);
 
+        fragment.onViewCreated(null, null);
+        assertFalse(attachTestSub.isUnsubscribed());
+        assertFalse(createTestSub.isUnsubscribed());
+        assertFalse(createViewTestSub.isUnsubscribed());
+        TestSubscriber<Object> viewCreatedTestSub = new TestSubscriber<>();
+        observable.compose(provider.bindToLifecycle()).subscribe(viewCreatedTestSub);
+
         fragment.onStart();
         assertFalse(attachTestSub.isUnsubscribed());
         assertFalse(createTestSub.isUnsubscribed());
         assertFalse(createViewTestSub.isUnsubscribed());
+        assertFalse(viewCreatedTestSub.isUnsubscribed());
         TestSubscriber<Object> startTestSub = new TestSubscriber<>();
         observable.compose(provider.bindToLifecycle()).subscribe(startTestSub);
 
@@ -153,6 +161,7 @@ public class RxSupportFragmentLifecycleTest {
         assertFalse(attachTestSub.isUnsubscribed());
         assertFalse(createTestSub.isUnsubscribed());
         assertFalse(createViewTestSub.isUnsubscribed());
+        assertFalse(viewCreatedTestSub.isUnsubscribed());
         assertFalse(startTestSub.isUnsubscribed());
         TestSubscriber<Object> resumeTestSub = new TestSubscriber<>();
         observable.compose(provider.bindToLifecycle()).subscribe(resumeTestSub);
@@ -161,6 +170,7 @@ public class RxSupportFragmentLifecycleTest {
         assertFalse(attachTestSub.isUnsubscribed());
         assertFalse(createTestSub.isUnsubscribed());
         assertFalse(createViewTestSub.isUnsubscribed());
+        assertFalse(viewCreatedTestSub.isUnsubscribed());
         assertFalse(startTestSub.isUnsubscribed());
         resumeTestSub.assertCompleted();
         resumeTestSub.assertUnsubscribed();
@@ -171,6 +181,7 @@ public class RxSupportFragmentLifecycleTest {
         assertFalse(attachTestSub.isUnsubscribed());
         assertFalse(createTestSub.isUnsubscribed());
         assertFalse(createViewTestSub.isUnsubscribed());
+        assertFalse(viewCreatedTestSub.isUnsubscribed());
         startTestSub.assertCompleted();
         startTestSub.assertUnsubscribed();
         pauseTestSub.assertCompleted();
@@ -183,6 +194,8 @@ public class RxSupportFragmentLifecycleTest {
         assertFalse(createTestSub.isUnsubscribed());
         createViewTestSub.assertCompleted();
         createViewTestSub.assertUnsubscribed();
+        viewCreatedTestSub.assertCompleted();
+        viewCreatedTestSub.assertUnsubscribed();
         stopTestSub.assertCompleted();
         stopTestSub.assertUnsubscribed();
         TestSubscriber<Object> destroyViewTestSub = new TestSubscriber<>();


### PR DESCRIPTION
Fixes #131 

* Updated test to check if subscriptions made in `onCreateView` as well as `onViewCreated` are properly unsubscribed in `onDestroyView`
* Modified lifecycle test to call `onCreateView` instead of `onViewCreated`
* Modified `RxDialogFragment` and `RxFragment` to call `onNext(CREATE_VEW)` as part of `onCreateView`
* Also modified the support fragment versions as well