### PR TITLE
Add LifecycleProvider superinterface for ActivityLifecycleProvider and FragmentLifecycleProvider

### DIFF
--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/ActivityLifecycleProvider.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/ActivityLifecycleProvider.java
@@ -1,45 +1,10 @@
 package com.trello.rxlifecycle;
 
-import android.support.annotation.CheckResult;
-import android.support.annotation.NonNull;
-import rx.Observable;
-
 /**
  * Common interface for all RxActivity extensions.
  *
  * Useful if you are writing utilities on top of rxlifecycle-components
  * or implementing your own component not supported by this library.
  */
-public interface ActivityLifecycleProvider {
-
-    /**
-     * @return a sequence of {@link android.app.Activity} lifecycle events
-     */
-    @NonNull
-    @CheckResult
-    Observable<ActivityEvent> lifecycle();
-
-    /**
-     * Binds a source until a specific {@link ActivityEvent} occurs.
-     * <p>
-     * Intended for use with {@link Observable#compose(Observable.Transformer)}
-     *
-     * @param event the {@link ActivityEvent} that triggers unsubscription
-     * @return a reusable {@link Observable.Transformer} which unsubscribes when the event triggers.
-     */
-    @NonNull
-    @CheckResult
-    <T> LifecycleTransformer<T> bindUntilEvent(@NonNull ActivityEvent event);
-
-    /**
-     * Binds a source until the next reasonable {@link ActivityEvent} occurs.
-     * <p>
-     * Intended for use with {@link Observable#compose(Observable.Transformer)}
-     *
-     * @return a reusable {@link Observable.Transformer} which unsubscribes at the correct time.
-     */
-    @NonNull
-    @CheckResult
-    <T> LifecycleTransformer<T> bindToLifecycle();
-
+public interface ActivityLifecycleProvider extends LifecycleProvider<ActivityEvent> {
 }

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/FragmentLifecycleProvider.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/FragmentLifecycleProvider.java
@@ -1,45 +1,10 @@
 package com.trello.rxlifecycle;
 
-import android.support.annotation.CheckResult;
-import android.support.annotation.NonNull;
-import rx.Observable;
-
 /**
  * Common interface for all RxFragment extensions.
  *
  * Useful if you are writing utilities on top of rxlifecycle-components
  * or implementing your own component not supported by this library.
  */
-public interface FragmentLifecycleProvider {
-
-    /**
-     * @return a sequence of {@link android.app.Fragment} lifecycle events
-     */
-    @NonNull
-    @CheckResult
-    Observable<FragmentEvent> lifecycle();
-
-    /**
-     * Binds a source until a specific {@link FragmentEvent} occurs.
-     * <p>
-     * Intended for use with {@link Observable#compose(Observable.Transformer)}
-     *
-     * @param event the {@link FragmentEvent} that triggers unsubscription
-     * @return a reusable {@link Observable.Transformer} which unsubscribes when the event triggers.
-     */
-    @NonNull
-    @CheckResult
-    <T> LifecycleTransformer<T> bindUntilEvent(@NonNull FragmentEvent event);
-
-    /**
-     * Binds a source until the next reasonable {@link FragmentEvent} occurs.
-     * <p>
-     * Intended for use with {@link Observable#compose(Observable.Transformer)}
-     *
-     * @return a reusable {@link Observable.Transformer} which unsubscribes at the correct time.
-     */
-    @NonNull
-    @CheckResult
-    <T> LifecycleTransformer<T> bindToLifecycle();
-
+public interface FragmentLifecycleProvider extends LifecycleProvider<FragmentEvent> {
 }

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/LifecycleProvider.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/LifecycleProvider.java
@@ -1,0 +1,44 @@
+package com.trello.rxlifecycle;
+
+import android.support.annotation.CheckResult;
+import android.support.annotation.NonNull;
+
+import rx.Observable;
+
+/**
+ * Common base interface for activity and fragment lifecycle providers.
+ *
+ * Useful if you are writing utilities on top of rxlifecycle-components
+ * or implementing your own component not supported by this library.
+ */
+public interface LifecycleProvider<E> {
+    /**
+     * @return a sequence of lifecycle events
+     */
+    @NonNull
+    @CheckResult
+    Observable<E> lifecycle();
+
+    /**
+     * Binds a source until a specific event occurs.
+     * <p>
+     * Intended for use with {@link Observable#compose(Observable.Transformer)}
+     *
+     * @param event the event that triggers unsubscription
+     * @return a reusable {@link Observable.Transformer} which unsubscribes when the event triggers.
+     */
+    @NonNull
+    @CheckResult
+    <T> LifecycleTransformer<T> bindUntilEvent(@NonNull E event);
+
+    /**
+     * Binds a source until the next reasonable event occurs.
+     * <p>
+     * Intended for use with {@link Observable#compose(Observable.Transformer)}
+     *
+     * @return a reusable {@link Observable.Transformer} which unsubscribes at the correct time.
+     */
+    @NonNull
+    @CheckResult
+    <T> LifecycleTransformer<T> bindToLifecycle();
+}


### PR DESCRIPTION
This adds a superinterface that contains the three methods shared by the `ActivityLifecycleProvider` and `FragmentLifecycleProvider` classes.