### PR TITLE
Upgraded to support RxJava 1.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ ext {
     targetCompatibilityVersion = JavaVersion.VERSION_1_7
 
     // Define all dependencies in the base project, to unify & make it easy to update
-    rxJava = 'io.reactivex:rxjava:1.2.0'
+    rxJava = 'io.reactivex:rxjava:1.2.1'
     rxBinding = 'com.jakewharton.rxbinding:rxbinding:0.4.0'
     navi = 'com.trello:navi:0.2.2'
     kotlinStdlib = "org.jetbrains.kotlin:kotlin-stdlib:$verKotlin"

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilCorrespondingEventSingleTransformerTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilCorrespondingEventSingleTransformerTest.java
@@ -5,28 +5,33 @@ import org.junit.Test;
 import rx.Single;
 import rx.functions.Func1;
 import rx.observers.TestSubscriber;
+import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
 
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
 
 public class UntilCorrespondingEventSingleTransformerTest {
 
     PublishSubject<String> lifecycle;
     TestSubscriber<String> testSubscriber;
+    TestScheduler testScheduler; // Since Single is not backpressure aware, use this to simulate it taking time
 
     @Before
     public void setup() {
         lifecycle = PublishSubject.create();
-        testSubscriber = new TestSubscriber<>(0);
+        testSubscriber = new TestSubscriber<>();
+        testScheduler = new TestScheduler();
     }
 
     @Test
     public void noEvents() {
         Single.just("1")
+            .delay(1, TimeUnit.MILLISECONDS, testScheduler)
             .compose(new UntilCorrespondingEventSingleTransformer<String, String>(lifecycle, CORRESPONDING_EVENTS))
             .subscribe(testSubscriber);
 
-        testSubscriber.requestMore(1);
+        testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
         testSubscriber.assertValue("1");
         testSubscriber.assertCompleted();
     }
@@ -34,11 +39,12 @@ public class UntilCorrespondingEventSingleTransformerTest {
     @Test
     public void oneStartEvent() {
         Single.just("1")
+            .delay(1, TimeUnit.MILLISECONDS, testScheduler)
             .compose(new UntilCorrespondingEventSingleTransformer<String, String>(lifecycle, CORRESPONDING_EVENTS))
             .subscribe(testSubscriber);
 
         lifecycle.onNext("create");
-        testSubscriber.requestMore(1);
+        testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
         testSubscriber.assertValue("1");
         testSubscriber.assertCompleted();
     }
@@ -46,12 +52,13 @@ public class UntilCorrespondingEventSingleTransformerTest {
     @Test
     public void twoOpenEvents() {
         Single.just("1")
+            .delay(1, TimeUnit.MILLISECONDS, testScheduler)
             .compose(new UntilCorrespondingEventSingleTransformer<String, String>(lifecycle, CORRESPONDING_EVENTS))
             .subscribe(testSubscriber);
 
         lifecycle.onNext("create");
         lifecycle.onNext("start");
-        testSubscriber.requestMore(1);
+        testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
         testSubscriber.assertValue("1");
         testSubscriber.assertCompleted();
     }
@@ -59,12 +66,13 @@ public class UntilCorrespondingEventSingleTransformerTest {
     @Test
     public void openAndCloseEvent() {
         Single.just("1")
+            .delay(1, TimeUnit.MILLISECONDS, testScheduler)
             .compose(new UntilCorrespondingEventSingleTransformer<String, String>(lifecycle, CORRESPONDING_EVENTS))
             .subscribe(testSubscriber);
 
         lifecycle.onNext("create");
         lifecycle.onNext("destroy");
-        testSubscriber.requestMore(1);
+        testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
         testSubscriber.assertNoValues();
         testSubscriber.assertError(CancellationException.class);
     }

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilCorrespondingEventSingleTransformerTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilCorrespondingEventSingleTransformerTest.java
@@ -31,6 +31,8 @@ public class UntilCorrespondingEventSingleTransformerTest {
             .compose(new UntilCorrespondingEventSingleTransformer<String, String>(lifecycle, CORRESPONDING_EVENTS))
             .subscribe(testSubscriber);
 
+        testSubscriber.assertNoValues();
+
         testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
         testSubscriber.assertValue("1");
         testSubscriber.assertCompleted();
@@ -42,6 +44,8 @@ public class UntilCorrespondingEventSingleTransformerTest {
             .delay(1, TimeUnit.MILLISECONDS, testScheduler)
             .compose(new UntilCorrespondingEventSingleTransformer<String, String>(lifecycle, CORRESPONDING_EVENTS))
             .subscribe(testSubscriber);
+
+        testSubscriber.assertNoValues();
 
         lifecycle.onNext("create");
         testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
@@ -55,6 +59,8 @@ public class UntilCorrespondingEventSingleTransformerTest {
             .delay(1, TimeUnit.MILLISECONDS, testScheduler)
             .compose(new UntilCorrespondingEventSingleTransformer<String, String>(lifecycle, CORRESPONDING_EVENTS))
             .subscribe(testSubscriber);
+
+        testSubscriber.assertNoValues();
 
         lifecycle.onNext("create");
         lifecycle.onNext("start");
@@ -71,6 +77,8 @@ public class UntilCorrespondingEventSingleTransformerTest {
             .subscribe(testSubscriber);
 
         lifecycle.onNext("create");
+        testSubscriber.assertNoErrors();
+
         lifecycle.onNext("destroy");
         testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
         testSubscriber.assertNoValues();

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilEventSingleTransformerTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilEventSingleTransformerTest.java
@@ -4,28 +4,33 @@ import org.junit.Before;
 import org.junit.Test;
 import rx.Single;
 import rx.observers.TestSubscriber;
+import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
 
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
 
 public class UntilEventSingleTransformerTest {
 
     PublishSubject<String> lifecycle;
     TestSubscriber<String> testSubscriber;
+    TestScheduler testScheduler; // Since Single is not backpressure aware, use this to simulate it taking time
 
     @Before
     public void setup() {
         lifecycle = PublishSubject.create();
-        testSubscriber = new TestSubscriber<>(0);
+        testSubscriber = new TestSubscriber<>();
+        testScheduler = new TestScheduler();
     }
 
     @Test
     public void noEvents() {
         Single.just("1")
+            .delay(1, TimeUnit.MILLISECONDS, testScheduler)
             .compose(new UntilEventSingleTransformer<String, String>(lifecycle, "stop"))
             .subscribe(testSubscriber);
 
-        testSubscriber.requestMore(1);
+        testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
         testSubscriber.assertValue("1");
         testSubscriber.assertCompleted();
     }
@@ -33,11 +38,12 @@ public class UntilEventSingleTransformerTest {
     @Test
     public void oneWrongEvent() {
         Single.just("1")
+            .delay(1, TimeUnit.MILLISECONDS, testScheduler)
             .compose(new UntilEventSingleTransformer<String, String>(lifecycle, "stop"))
             .subscribe(testSubscriber);
 
         lifecycle.onNext("keep going");
-        testSubscriber.requestMore(1);
+        testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
         testSubscriber.assertValue("1");
         testSubscriber.assertCompleted();
@@ -46,12 +52,13 @@ public class UntilEventSingleTransformerTest {
     @Test
     public void twoEvents() {
         Single.just("1")
+            .delay(1, TimeUnit.MILLISECONDS, testScheduler)
             .compose(new UntilEventSingleTransformer<String, String>(lifecycle, "stop"))
             .subscribe(testSubscriber);
 
         lifecycle.onNext("keep going");
         lifecycle.onNext("stop");
-        testSubscriber.requestMore(1);
+        testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
         testSubscriber.assertNoValues();
         testSubscriber.assertError(CancellationException.class);

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilEventSingleTransformerTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilEventSingleTransformerTest.java
@@ -30,6 +30,8 @@ public class UntilEventSingleTransformerTest {
             .compose(new UntilEventSingleTransformer<String, String>(lifecycle, "stop"))
             .subscribe(testSubscriber);
 
+        testSubscriber.assertNoValues();
+
         testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
         testSubscriber.assertValue("1");
         testSubscriber.assertCompleted();
@@ -41,6 +43,8 @@ public class UntilEventSingleTransformerTest {
             .delay(1, TimeUnit.MILLISECONDS, testScheduler)
             .compose(new UntilEventSingleTransformer<String, String>(lifecycle, "stop"))
             .subscribe(testSubscriber);
+
+        testSubscriber.assertNoValues();
 
         lifecycle.onNext("keep going");
         testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
@@ -57,6 +61,8 @@ public class UntilEventSingleTransformerTest {
             .subscribe(testSubscriber);
 
         lifecycle.onNext("keep going");
+        testSubscriber.assertNoErrors();
+
         lifecycle.onNext("stop");
         testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilLifecycleSingleTransformerTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilLifecycleSingleTransformerTest.java
@@ -4,28 +4,33 @@ import org.junit.Before;
 import org.junit.Test;
 import rx.Single;
 import rx.observers.TestSubscriber;
+import rx.schedulers.TestScheduler;
 import rx.subjects.PublishSubject;
 
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
 
 public class UntilLifecycleSingleTransformerTest {
 
     PublishSubject<String> lifecycle;
     TestSubscriber<String> testSubscriber;
+    TestScheduler testScheduler; // Since Single is not backpressure aware, use this to simulate it taking time
 
     @Before
     public void setup() {
         lifecycle = PublishSubject.create();
-        testSubscriber = new TestSubscriber<>(0);
+        testSubscriber = new TestSubscriber<>();
+        testScheduler = new TestScheduler();
     }
 
     @Test
     public void noEvent() {
         Single.just("1")
+            .delay(1, TimeUnit.MILLISECONDS, testScheduler)
             .compose(new UntilLifecycleSingleTransformer<String, String>(lifecycle))
             .subscribe(testSubscriber);
 
-        testSubscriber.requestMore(1);
+        testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
         testSubscriber.assertValue("1");
         testSubscriber.assertCompleted();
     }
@@ -33,11 +38,12 @@ public class UntilLifecycleSingleTransformerTest {
     @Test
     public void oneEvent() {
         Single.just("1")
+            .delay(1, TimeUnit.MILLISECONDS, testScheduler)
             .compose(new UntilLifecycleSingleTransformer<String, String>(lifecycle))
             .subscribe(testSubscriber);
 
         lifecycle.onNext("stop");
-        testSubscriber.requestMore(1);
+        testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
         testSubscriber.assertNoValues();
         testSubscriber.assertError(CancellationException.class);

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilLifecycleSingleTransformerTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle/UntilLifecycleSingleTransformerTest.java
@@ -30,6 +30,8 @@ public class UntilLifecycleSingleTransformerTest {
             .compose(new UntilLifecycleSingleTransformer<String, String>(lifecycle))
             .subscribe(testSubscriber);
 
+        testSubscriber.assertNoValues();
+
         testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
         testSubscriber.assertValue("1");
         testSubscriber.assertCompleted();
@@ -41,6 +43,8 @@ public class UntilLifecycleSingleTransformerTest {
             .delay(1, TimeUnit.MILLISECONDS, testScheduler)
             .compose(new UntilLifecycleSingleTransformer<String, String>(lifecycle))
             .subscribe(testSubscriber);
+
+        testSubscriber.assertNoErrors();
 
         lifecycle.onNext("stop");
         testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
The tests errantly believed that Single was backpressure aware. It's
not. Now we use a TestScheduler to control the emissions of the
Single for timing purposes.