### PR TITLE
Made all components abstract

### DIFF
--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxActivity.java
@@ -14,7 +14,7 @@ import com.trello.rxlifecycle.android.RxLifecycleAndroid;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
-public class RxActivity extends Activity implements LifecycleProvider<ActivityEvent> {
+public abstract class RxActivity extends Activity implements LifecycleProvider<ActivityEvent> {
 
     private final BehaviorSubject<ActivityEvent> lifecycleSubject = BehaviorSubject.create();
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxDialogFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxDialogFragment.java
@@ -15,7 +15,7 @@ import com.trello.rxlifecycle.android.RxLifecycleAndroid;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
-public class RxDialogFragment extends DialogFragment implements LifecycleProvider<FragmentEvent> {
+public abstract class RxDialogFragment extends DialogFragment implements LifecycleProvider<FragmentEvent> {
 
     private final BehaviorSubject<FragmentEvent> lifecycleSubject = BehaviorSubject.create();
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxFragment.java
@@ -15,7 +15,7 @@ import com.trello.rxlifecycle.android.RxLifecycleAndroid;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
-public class RxFragment extends Fragment implements LifecycleProvider<FragmentEvent> {
+public abstract class RxFragment extends Fragment implements LifecycleProvider<FragmentEvent> {
 
     private final BehaviorSubject<FragmentEvent> lifecycleSubject = BehaviorSubject.create();
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxPreferenceFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/RxPreferenceFragment.java
@@ -17,7 +17,7 @@ import com.trello.rxlifecycle.android.RxLifecycleAndroid;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
-public class RxPreferenceFragment extends PreferenceFragment implements LifecycleProvider<FragmentEvent> {
+public abstract class RxPreferenceFragment extends PreferenceFragment implements LifecycleProvider<FragmentEvent> {
 
     private final BehaviorSubject<FragmentEvent> lifecycleSubject = BehaviorSubject.create();
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxAppCompatActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxAppCompatActivity.java
@@ -14,7 +14,7 @@ import com.trello.rxlifecycle.android.RxLifecycleAndroid;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
-public class RxAppCompatActivity extends AppCompatActivity implements LifecycleProvider<ActivityEvent> {
+public abstract class RxAppCompatActivity extends AppCompatActivity implements LifecycleProvider<ActivityEvent> {
 
     private final BehaviorSubject<ActivityEvent> lifecycleSubject = BehaviorSubject.create();
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxAppCompatDialogFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxAppCompatDialogFragment.java
@@ -15,7 +15,7 @@ import com.trello.rxlifecycle.android.RxLifecycleAndroid;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
-public class RxAppCompatDialogFragment extends AppCompatDialogFragment implements LifecycleProvider<FragmentEvent> {
+public abstract class RxAppCompatDialogFragment extends AppCompatDialogFragment implements LifecycleProvider<FragmentEvent> {
 
     private final BehaviorSubject<FragmentEvent> lifecycleSubject = BehaviorSubject.create();
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxDialogFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxDialogFragment.java
@@ -15,7 +15,7 @@ import com.trello.rxlifecycle.android.RxLifecycleAndroid;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
-public class RxDialogFragment extends DialogFragment implements LifecycleProvider<FragmentEvent> {
+public abstract class RxDialogFragment extends DialogFragment implements LifecycleProvider<FragmentEvent> {
 
     private final BehaviorSubject<FragmentEvent> lifecycleSubject = BehaviorSubject.create();
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragment.java
@@ -14,7 +14,7 @@ import com.trello.rxlifecycle.android.RxLifecycleAndroid;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
-public class RxFragment extends Fragment implements LifecycleProvider<FragmentEvent> {
+public abstract class RxFragment extends Fragment implements LifecycleProvider<FragmentEvent> {
 
     private final BehaviorSubject<FragmentEvent> lifecycleSubject = BehaviorSubject.create();
 

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragmentActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle/components/support/RxFragmentActivity.java
@@ -14,7 +14,7 @@ import com.trello.rxlifecycle.android.RxLifecycleAndroid;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
-public class RxFragmentActivity extends FragmentActivity implements LifecycleProvider<ActivityEvent> {
+public abstract class RxFragmentActivity extends FragmentActivity implements LifecycleProvider<ActivityEvent> {
 
     private final BehaviorSubject<ActivityEvent> lifecycleSubject = BehaviorSubject.create();
 

--- a/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/RxActivityLifecycleTest.java
+++ b/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/RxActivityLifecycleTest.java
@@ -43,16 +43,16 @@ public class RxActivityLifecycleTest {
 
     @Test
     public void testRxActivity() {
-        testLifecycle(Robolectric.buildActivity(RxActivity.class));
-        testBindUntilEvent(Robolectric.buildActivity(RxActivity.class));
-        testBindToLifecycle(Robolectric.buildActivity(RxActivity.class));
+        testLifecycle(Robolectric.buildActivity(TestRxActivity.class));
+        testBindUntilEvent(Robolectric.buildActivity(TestRxActivity.class));
+        testBindToLifecycle(Robolectric.buildActivity(TestRxActivity.class));
     }
 
     @Test
     public void testRxFragmentActivity() {
-        testLifecycle(Robolectric.buildActivity(RxFragmentActivity.class));
-        testBindUntilEvent(Robolectric.buildActivity(RxFragmentActivity.class));
-        testBindToLifecycle(Robolectric.buildActivity(RxFragmentActivity.class));
+        testLifecycle(Robolectric.buildActivity(TestRxFragmentActivity.class));
+        testBindUntilEvent(Robolectric.buildActivity(TestRxFragmentActivity.class));
+        testBindToLifecycle(Robolectric.buildActivity(TestRxFragmentActivity.class));
     }
 
     @Test
@@ -147,5 +147,13 @@ public class RxActivityLifecycleTest {
         createTestSub.assertUnsubscribed();
         stopTestSub.assertCompleted();
         stopTestSub.assertUnsubscribed();
+    }
+
+    // These classes are just for testing since components are abstract
+
+    public static class TestRxActivity extends RxActivity {
+    }
+
+    public static class TestRxFragmentActivity extends RxFragmentActivity{
     }
 }

--- a/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/RxFragmentLifecycleTest.java
+++ b/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/RxFragmentLifecycleTest.java
@@ -42,23 +42,23 @@ public class RxFragmentLifecycleTest {
 
     @Test
     public void testRxFragment() {
-        testLifecycle(new RxFragment());
-        testBindUntilEvent(new RxFragment());
-        testBindToLifecycle(new RxFragment());
+        testLifecycle(new TestRxFragment());
+        testBindUntilEvent(new TestRxFragment());
+        testBindToLifecycle(new TestRxFragment());
     }
 
     @Test
     public void testRxDialogFragment() {
-        testLifecycle(new RxDialogFragment());
-        testBindUntilEvent(new RxDialogFragment());
-        testBindToLifecycle(new RxDialogFragment());
+        testLifecycle(new TestRxDialogFragment());
+        testBindUntilEvent(new TestRxDialogFragment());
+        testBindToLifecycle(new TestRxDialogFragment());
     }
 
     @Test
     public void testRxPreferenceFragment() {
-        testLifecycle(new RxPreferenceFragment());
-        testBindUntilEvent(new RxPreferenceFragment());
-        testBindToLifecycle(new RxPreferenceFragment());
+        testLifecycle(new TestRxPreferenceFragment());
+        testBindUntilEvent(new TestRxPreferenceFragment());
+        testBindToLifecycle(new TestRxPreferenceFragment());
     }
 
     private void testLifecycle(LifecycleProvider<FragmentEvent> provider) {
@@ -198,5 +198,16 @@ public class RxFragmentLifecycleTest {
         attachTestSub.assertUnsubscribed();
         destroyTestSub.assertCompleted();
         destroyTestSub.assertUnsubscribed();
+    }
+
+    // These classes are just for testing since components are abstract
+
+    public static class TestRxFragment extends RxFragment {
+    }
+
+    public static class TestRxDialogFragment extends RxDialogFragment {
+    }
+
+    public static class TestRxPreferenceFragment extends RxPreferenceFragment {
     }
 }

--- a/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/support/RxSupportFragmentLifecycleTest.java
+++ b/rxlifecycle-components/src/test/java/com/trello/rxlifecycle/components/support/RxSupportFragmentLifecycleTest.java
@@ -43,16 +43,16 @@ public class RxSupportFragmentLifecycleTest {
 
     @Test
     public void testRxFragment() {
-        testLifecycle(new RxFragment());
-        testBindUntilEvent(new RxFragment());
-        testBindToLifecycle(new RxFragment());
+        testLifecycle(new TestRxFragment());
+        testBindUntilEvent(new TestRxFragment());
+        testBindToLifecycle(new TestRxFragment());
     }
 
     @Test
     public void testRxDialogFragment() {
-        testLifecycle(new RxDialogFragment());
-        testBindUntilEvent(new RxDialogFragment());
-        testBindToLifecycle(new RxDialogFragment());
+        testLifecycle(new TestRxDialogFragment());
+        testBindUntilEvent(new TestRxDialogFragment());
+        testBindToLifecycle(new TestRxDialogFragment());
     }
 
     @Test
@@ -210,5 +210,13 @@ public class RxSupportFragmentLifecycleTest {
             .beginTransaction()
             .add(fragment, null)
             .commit();
+    }
+
+    // These classes are just for testing since components are abstract
+
+    public static class TestRxFragment extends RxFragment {
+    }
+
+    public static class TestRxDialogFragment extends RxDialogFragment {
     }
 }


### PR DESCRIPTION
This both prevents the compiler from warning about unregistered
Activities and also signals to users that these classes are intended
to be subclassed.