### PR TITLE
Leverage flatMapCompletable

### DIFF
--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/Functions.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/Functions.java
@@ -1,10 +1,9 @@
 package com.trello.rxlifecycle;
 
-import io.reactivex.Observable;
+import io.reactivex.Completable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.functions.Predicate;
-
 import java.util.concurrent.CancellationException;
 
 final class Functions {
@@ -29,10 +28,10 @@ final class Functions {
         }
     };
 
-    static final Function<Object, Observable<Object>> CANCEL_COMPLETABLE = new Function<Object, Observable<Object>>() {
+    static final Function<Object, Completable> CANCEL_COMPLETABLE = new Function<Object, Completable>() {
         @Override
-        public Observable<Object> apply(Object ignore) throws Exception {
-            return Observable.error(new CancellationException());
+        public Completable apply(Object ignore) throws Exception {
+            return Completable.error(new CancellationException());
         }
     };
 

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilCorrespondingEventTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilCorrespondingEventTransformer.java
@@ -46,8 +46,7 @@ final class UntilCorrespondingEventTransformer<T, R> implements LifecycleTransfo
         return Completable.ambArray(
             upstream,
             takeUntilCorrespondingEvent(sharedLifecycle, correspondingEvents)
-                .flatMap(Functions.CANCEL_COMPLETABLE)
-                .ignoreElements()
+                .flatMapCompletable(Functions.CANCEL_COMPLETABLE)
         );
     }
 

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilEventTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilEventTransformer.java
@@ -41,8 +41,7 @@ final class UntilEventTransformer<T, R> implements LifecycleTransformer<T> {
         return Completable.ambArray(
             upstream,
             takeUntilEvent(lifecycle, event)
-                .flatMap(Functions.CANCEL_COMPLETABLE)
-                .ignoreElements()
+                .flatMapCompletable(Functions.CANCEL_COMPLETABLE)
         );
     }
 

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilLifecycleTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle/UntilLifecycleTransformer.java
@@ -37,8 +37,7 @@ final class UntilLifecycleTransformer<T, R> implements LifecycleTransformer<T> {
         return Completable.ambArray(
             upstream,
             lifecycle
-                .flatMap(Functions.CANCEL_COMPLETABLE)
-                .ignoreElements()
+                .flatMapCompletable(Functions.CANCEL_COMPLETABLE)
         );
     }
 


### PR DESCRIPTION
Just saw it while you were changing the Completable.ambArray call

Not only less methods that are being used. `flatMapCompletable` is also faster since the entire 'flattening' part is left out and internal optimizations can be applied since it knows that Completable either completes or errors.