### PR TITLE
1.x: Remove RxBinding dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,10 +34,11 @@ ext {
 
     // Define all dependencies in the base project, to unify & make it easy to update
     rxJava = 'io.reactivex:rxjava:1.2.1'
-    rxBinding = 'com.jakewharton.rxbinding:rxbinding:0.4.0'
+    rxAndroid = 'io.reactivex:rxandroid:1.2.1'
     navi = 'com.trello:navi:1.0'
     kotlinStdlib = "org.jetbrains.kotlin:kotlin-stdlib:$verKotlin"
     appCompat = 'com.android.support:appcompat-v7:25.0.0'
+    supportAnnotations = 'com.android.support:support-annotations:25.0.0'
     jsr305Annotations = 'com.google.code.findbugs:jsr305:3.0.1'
     junit = 'junit:junit:4.12'
     robolectric = 'org.robolectric:robolectric:3.1.4'

--- a/rxlifecycle-android/build.gradle
+++ b/rxlifecycle-android/build.gradle
@@ -16,8 +16,8 @@ repositories {
 
 dependencies {
     compile project(':rxlifecycle')
-
-    compile rootProject.ext.rxBinding
+    compile rootProject.ext.rxAndroid
+    compile rootProject.ext.supportAnnotations
 
     testCompile rootProject.ext.junit
     testCompile rootProject.ext.robolectric

--- a/rxlifecycle-android/src/main/java/com/trello/rxlifecycle/android/RxLifecycleAndroid.java
+++ b/rxlifecycle-android/src/main/java/com/trello/rxlifecycle/android/RxLifecycleAndroid.java
@@ -17,7 +17,6 @@ package com.trello.rxlifecycle.android;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.view.View;
-import com.jakewharton.rxbinding.view.RxView;
 import com.trello.rxlifecycle.*;
 import rx.Observable;
 import rx.functions.Func1;
@@ -98,7 +97,7 @@ public class RxLifecycleAndroid {
     public static <T> LifecycleTransformer<T> bindView(@NonNull final View view) {
         checkNotNull(view, "view == null");
 
-        return bind(RxView.detaches(view));
+        return bind(Observable.create(new ViewDetachesObservable(view)));
     }
 
     // Figures out which corresponding next lifecycle event in which to unsubscribe, for Activities

--- a/rxlifecycle-android/src/main/java/com/trello/rxlifecycle/android/ViewDetachesObservable.java
+++ b/rxlifecycle-android/src/main/java/com/trello/rxlifecycle/android/ViewDetachesObservable.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.trello.rxlifecycle.android;
+
+import android.view.View;
+import rx.Observable;
+import rx.Subscriber;
+import rx.android.MainThreadSubscription;
+
+import static rx.android.MainThreadSubscription.verifyMainThread;
+
+final class ViewDetachesObservable implements Observable.OnSubscribe<Object> {
+    private static final Object SIGNAL = new Object();
+    private final View view;
+
+    ViewDetachesObservable(View view) {
+        this.view = view;
+    }
+
+    @Override
+    public void call(final Subscriber<? super Object> subscriber) {
+        verifyMainThread();
+
+        final View.OnAttachStateChangeListener listener = new View.OnAttachStateChangeListener() {
+            @Override
+            public void onViewAttachedToWindow(View v) {
+                // Do nothing
+            }
+
+            @Override
+            public void onViewDetachedFromWindow(View v) {
+                if (!subscriber.isUnsubscribed()) {
+                    subscriber.onNext(SIGNAL);
+                }
+            }
+        };
+
+        subscriber.add(new MainThreadSubscription() {
+            @Override
+            protected void onUnsubscribe() {
+                view.removeOnAttachStateChangeListener(listener);
+            }
+        });
+
+        view.addOnAttachStateChangeListener(listener);
+    }
+}


### PR DESCRIPTION
The RxBinding library was only used for sending notification when view gets detached but nothing else. However, it does increases methods count by a few hundred, so I just port the `RxViews#detaches` over in this PR.

Didn't add any unit tests since the `RxLifecycleTest#testBindView` already covers the change.

Hope this PR would make sense.