### PR TITLE
Move FragmentEvent.CREATE_VIEW emission to onCreateView()

### DIFF
--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle2/components/RxFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle2/components/RxFragment.java
@@ -20,7 +20,10 @@ import android.support.annotation.CallSuper;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
+
 import com.trello.rxlifecycle2.LifecycleProvider;
 import com.trello.rxlifecycle2.LifecycleTransformer;
 import com.trello.rxlifecycle2.RxLifecycle;
@@ -68,11 +71,13 @@ public abstract class RxFragment extends Fragment implements LifecycleProvider<F
         lifecycleSubject.onNext(FragmentEvent.CREATE);
     }
 
+    @Nullable
     @Override
     @CallSuper
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
+        super.onCreateView(inflater, container, savedInstanceState);
         lifecycleSubject.onNext(FragmentEvent.CREATE_VIEW);
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Previous the following code would not work:
```
@Override
public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
    View rootView = inflater.inflate(R.layout.fragment_test, container, false);
    ButterKnife.bind(this, rootView);

    RxTextView.textChanges(editText)
            .compose(this.<CharSequence>bindUntilEvent(FragmentEvent.DESTROY_VIEW))
            .subscribe(new Consumer<CharSequence>() {
                @Override
                public void accept(@NonNull CharSequence charSequence) throws Exception {
                    // Do something with text
                }
            });

    return rootView;
}
```

The issue is from #94. When returning to a `Fragment` on the backstack, the last `FragmentEvent` when `onCreateView` is called is `DESTROY_VIEW` which results in this subscription immediately completing.

The fix is to move the `onNext` of `FragmentEvent.CREATE_VIEW` to `onCreateView` and then call the super class:

```
@Override
public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
    super.onCreateView(inflater, container, savedInstanceState); // Must call to update RxFragment's lifecycle
    View rootView = inflater.inflate(R.layout.fragment_test, container, false);
    ButterKnife.bind(this, rootView);

    RxTextView.textChanges(editText)
            .compose(this.<CharSequence>bindUntilEvent(FragmentEvent.DESTROY_VIEW))
            .subscribe(new Consumer<CharSequence>() {
                @Override
                public void accept(@NonNull CharSequence charSequence) throws Exception {
                    // Do something with text
                }
            });

    return rootView;
}
```