### PR TITLE
Make JSR 305 compileOnly on 1.x branch

### DIFF
--- a/rxlifecycle/build.gradle
+++ b/rxlifecycle/build.gradle
@@ -9,7 +9,7 @@ repositories {
 
 dependencies {
     compile rootProject.ext.rxJava
-    compile rootProject.ext.jsr305Annotations
+    compileOnly rootProject.ext.jsr305Annotations
 
     testCompile rootProject.ext.junit
 }


### PR DESCRIPTION
This is the same fix as #219, but on the `1.x` branch for projects that haven't been able to migrate to RxJava2 yet.

I checked and it doesn't look like `javax.annotation.Nonnull` is used anywhere in the Android modules, so I didn't need to change any annotation usages.