### PR TITLE
Remove generic type declaration for Completable bindings.

### DIFF
--- a/rxlifecycle-android-lifecycle-kotlin/src/main/java/com/trello/rxlifecycle2/android/lifecycle/kotlin/rxlifecycle.kt
+++ b/rxlifecycle-android-lifecycle-kotlin/src/main/java/com/trello/rxlifecycle2/android/lifecycle/kotlin/rxlifecycle.kt
@@ -43,8 +43,8 @@ fun <T> Maybe<T>.bindToLifecycle(owner: LifecycleOwner): Maybe<T>
 fun <T> Maybe<T>.bindUntilEvent(owner: LifecycleOwner, event: Lifecycle.Event): Maybe<T>
         = this.compose(AndroidLifecycle.createLifecycleProvider(owner).bindUntilEvent(event))
 
-fun <T> Completable.bindToLifecycle(owner: LifecycleOwner): Completable
+fun Completable.bindToLifecycle(owner: LifecycleOwner): Completable
         = this.compose(AndroidLifecycle.createLifecycleProvider(owner).bindToLifecycle<Completable>())
 
-fun <T> Completable.bindUntilEvent(owner: LifecycleOwner, event: Lifecycle.Event): Completable
+fun Completable.bindUntilEvent(owner: LifecycleOwner, event: Lifecycle.Event): Completable
         = this.compose(AndroidLifecycle.createLifecycleProvider(owner).bindUntilEvent<Completable>(event))


### PR DESCRIPTION
Remove the unecessary generic type <T> from the kotlin extensions for binding to Completable chains. The type declared in the signature is not being used in the function, and doesn't make sense on a Completable, so this looks like a copy/paste error.

This fixes the following error, when not specifying a type:

    Type inference failed: Not enough information to infer parameter T in fun <T> Completable.bindUntilEvent(owner: LifecycleOwner, event: Lifecycle.Event): Completable