### PR TITLE
Create custom operators to cancel subscriptions

### DIFF
--- a/rxlifecycle-components-preference/src/test/java/com/trello/rxlifecycle2/components/preference/RxPreferenceFragmentLifecycleTest.java
+++ b/rxlifecycle-components-preference/src/test/java/com/trello/rxlifecycle2/components/preference/RxPreferenceFragmentLifecycleTest.java
@@ -19,7 +19,6 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import com.trello.rxlifecycle2.LifecycleProvider;
 import com.trello.rxlifecycle2.android.FragmentEvent;
-import io.reactivex.Observable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.PublishSubject;
 import org.junit.Before;
@@ -35,11 +34,11 @@ import static com.trello.rxlifecycle2.android.FragmentEvent.STOP;
 @Config(manifest = Config.NONE)
 public class RxPreferenceFragmentLifecycleTest {
 
-    private Observable<Object> observable;
+    private PublishSubject<Object> stream;
 
     @Before
     public void setup() {
-        observable = PublishSubject.create().hide();
+        stream = PublishSubject.create();
     }
 
     @Test
@@ -88,22 +87,30 @@ public class RxPreferenceFragmentLifecycleTest {
         Fragment fragment = (Fragment) provider;
         startFragment(fragment);
 
-        TestObserver<Object> testObserver = observable.compose(provider.bindUntilEvent(STOP)).test();
+        TestObserver<Object> testObserver = stream.hide().compose(provider.bindUntilEvent(STOP)).test();
 
         fragment.onAttach(null);
+        stream.onNext("attach");
         testObserver.assertNotComplete();
         fragment.onCreate(null);
+        stream.onNext("create");
         testObserver.assertNotComplete();
         fragment.onViewCreated(null, null);
+        stream.onNext("createView");
         testObserver.assertNotComplete();
         fragment.onStart();
+        stream.onNext("start");
         testObserver.assertNotComplete();
         fragment.onResume();
+        stream.onNext("resume");
         testObserver.assertNotComplete();
         fragment.onPause();
+        stream.onNext("pause");
         testObserver.assertNotComplete();
         fragment.onStop();
-        testObserver.assertComplete();
+        stream.onNext("stop");
+        testObserver.assertValues("attach", "create", "createView", "start", "resume", "pause");
+        testObserver.assertNotComplete();
     }
 
     // Tests bindToLifecycle for any given LifecycleProvider<FragmentEvent> implementation
@@ -112,62 +119,62 @@ public class RxPreferenceFragmentLifecycleTest {
         startFragment(fragment);
 
         fragment.onAttach(null);
-        TestObserver<Object> attachObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> attachObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("attach");
 
         fragment.onCreate(null);
-        attachObserver.assertNotComplete();
-        TestObserver<Object> createObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> createObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("create");
 
         fragment.onViewCreated(null, null);
-        attachObserver.assertNotComplete();
-        createObserver.assertNotComplete();
-        TestObserver<Object> createViewObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> createViewObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("createView");
 
         fragment.onStart();
-        attachObserver.assertNotComplete();
-        createObserver.assertNotComplete();
-        createViewObserver.assertNotComplete();
-        TestObserver<Object> startObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> startObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("start");
 
         fragment.onResume();
-        attachObserver.assertNotComplete();
-        createObserver.assertNotComplete();
-        createViewObserver.assertNotComplete();
-        startObserver.assertNotComplete();
-        TestObserver<Object> resumeObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> resumeObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("resume");
 
         fragment.onPause();
-        attachObserver.assertNotComplete();
-        createObserver.assertNotComplete();
-        createViewObserver.assertNotComplete();
-        startObserver.assertNotComplete();
-        resumeObserver.assertComplete();
-        TestObserver<Object> pauseObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> pauseObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("pause");
+        resumeObserver.assertNotComplete();
+        resumeObserver.assertValues("resume");
 
         fragment.onStop();
-        attachObserver.assertNotComplete();
-        createObserver.assertNotComplete();
-        createViewObserver.assertNotComplete();
-        startObserver.assertComplete();
-        pauseObserver.assertComplete();
-        TestObserver<Object> stopObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> stopObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("stop");
+        startObserver.assertNotComplete();
+        startObserver.assertValues("start", "resume", "pause");
+        pauseObserver.assertNotComplete();
+        pauseObserver.assertValues("pause");
 
         fragment.onDestroyView();
-        attachObserver.assertNotComplete();
-        createObserver.assertNotComplete();
-        createViewObserver.assertComplete();
-        stopObserver.assertComplete();
-        TestObserver<Object> destroyViewObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> destroyViewObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("destroyView");
+        createViewObserver.assertNotComplete();
+        createViewObserver.assertValues("createView", "start", "resume", "pause", "stop");
+        stopObserver.assertNotComplete();
+        stopObserver.assertValues("stop");
 
         fragment.onDestroy();
-        attachObserver.assertNotComplete();
-        createObserver.assertComplete();
-        destroyViewObserver.assertComplete();
-        TestObserver<Object> destroyObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> destroyObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("destroy");
+        createObserver.assertNotComplete();
+        createObserver.assertValues("create", "createView", "start", "resume", "pause", "stop", "destroyView");
+        destroyViewObserver.assertNotComplete();
+        destroyViewObserver.assertValues("destroyView");
 
         fragment.onDetach();
-        attachObserver.assertComplete();
-        destroyObserver.assertComplete();
+        stream.onNext("detach");
+        attachObserver.assertNotComplete();
+        attachObserver.assertValues("attach", "create", "createView", "start", "resume",
+                "pause", "stop", "destroyView", "destroy");
+        destroyObserver.assertNotComplete();
+        destroyObserver.assertValues("destroy");
     }
 
     // Easier than making everyone create their own shadows

--- a/rxlifecycle-components/src/test/java/com/trello/rxlifecycle2/components/support/RxSupportFragmentLifecycleTest.java
+++ b/rxlifecycle-components/src/test/java/com/trello/rxlifecycle2/components/support/RxSupportFragmentLifecycleTest.java
@@ -18,7 +18,6 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import com.trello.rxlifecycle2.LifecycleProvider;
 import com.trello.rxlifecycle2.android.FragmentEvent;
-import io.reactivex.Observable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.PublishSubject;
 import org.junit.Before;
@@ -34,11 +33,11 @@ import static com.trello.rxlifecycle2.android.FragmentEvent.STOP;
 @Config(manifest = Config.NONE)
 public class RxSupportFragmentLifecycleTest {
 
-    private Observable<Object> observable;
+    private PublishSubject<Object> stream;
 
     @Before
     public void setup() {
-        observable = PublishSubject.create().hide();
+        stream = PublishSubject.create();
     }
 
     @Test
@@ -101,22 +100,30 @@ public class RxSupportFragmentLifecycleTest {
         Fragment fragment = (Fragment) provider;
         startFragment(fragment);
 
-        TestObserver<Object> testObserver = observable.compose(provider.bindUntilEvent(STOP)).test();
+        TestObserver<Object> testObserver = stream.hide().compose(provider.bindUntilEvent(STOP)).test();
 
         fragment.onAttach(null);
+        stream.onNext("attach");
         testObserver.assertNotComplete();
         fragment.onCreate(null);
+        stream.onNext("create");
         testObserver.assertNotComplete();
         fragment.onViewCreated(null, null);
+        stream.onNext("createView");
         testObserver.assertNotComplete();
         fragment.onStart();
+        stream.onNext("start");
         testObserver.assertNotComplete();
         fragment.onResume();
+        stream.onNext("resume");
         testObserver.assertNotComplete();
         fragment.onPause();
+        stream.onNext("pause");
         testObserver.assertNotComplete();
         fragment.onStop();
-        testObserver.assertComplete();
+        stream.onNext("stop");
+        testObserver.assertValues("attach", "create", "createView", "start", "resume", "pause");
+        testObserver.assertNotComplete();
     }
 
     // Tests bindToLifecycle for any given LifecycleProvider<FragmentEvent> implementation
@@ -125,62 +132,62 @@ public class RxSupportFragmentLifecycleTest {
         startFragment(fragment);
 
         fragment.onAttach(null);
-        TestObserver<Object> attachObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> attachObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("attach");
 
         fragment.onCreate(null);
-        attachObserver.assertNotComplete();
-        TestObserver<Object> createObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> createObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("create");
 
         fragment.onViewCreated(null, null);
-        attachObserver.assertNotComplete();
-        createObserver.assertNotComplete();
-        TestObserver<Object> createViewObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> createViewObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("createView");
 
         fragment.onStart();
-        attachObserver.assertNotComplete();
-        createObserver.assertNotComplete();
-        createViewObserver.assertNotComplete();
-        TestObserver<Object> startObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> startObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("start");
 
         fragment.onResume();
-        attachObserver.assertNotComplete();
-        createObserver.assertNotComplete();
-        createViewObserver.assertNotComplete();
-        startObserver.assertNotComplete();
-        TestObserver<Object> resumeObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> resumeObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("resume");
 
         fragment.onPause();
-        attachObserver.assertNotComplete();
-        createObserver.assertNotComplete();
-        createViewObserver.assertNotComplete();
-        startObserver.assertNotComplete();
-        resumeObserver.assertComplete();
-        TestObserver<Object> pauseObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> pauseObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("pause");
+        resumeObserver.assertNotComplete();
+        resumeObserver.assertValues("resume");
 
         fragment.onStop();
-        attachObserver.assertNotComplete();
-        createObserver.assertNotComplete();
-        createViewObserver.assertNotComplete();
-        startObserver.assertComplete();
-        pauseObserver.assertComplete();
-        TestObserver<Object> stopObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> stopObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("stop");
+        startObserver.assertNotComplete();
+        startObserver.assertValues("start", "resume", "pause");
+        pauseObserver.assertNotComplete();
+        pauseObserver.assertValues("pause");
 
         fragment.onDestroyView();
-        attachObserver.assertNotComplete();
-        createObserver.assertNotComplete();
-        createViewObserver.assertComplete();
-        stopObserver.assertComplete();
-        TestObserver<Object> destroyViewObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> destroyViewObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("destroyView");
+        createViewObserver.assertNotComplete();
+        createViewObserver.assertValues("createView", "start", "resume", "pause", "stop");
+        stopObserver.assertNotComplete();
+        stopObserver.assertValues("stop");
 
         fragment.onDestroy();
-        attachObserver.assertNotComplete();
-        createObserver.assertComplete();
-        destroyViewObserver.assertComplete();
-        TestObserver<Object> destroyObserver = observable.compose(provider.bindToLifecycle()).test();
+        TestObserver<Object> destroyObserver = stream.hide().compose(provider.bindToLifecycle()).test();
+        stream.onNext("destroy");
+        createObserver.assertNotComplete();
+        createObserver.assertValues("create", "createView", "start", "resume", "pause", "stop", "destroyView");
+        destroyViewObserver.assertNotComplete();
+        destroyViewObserver.assertValues("destroyView");
 
         fragment.onDetach();
-        attachObserver.assertComplete();
-        destroyObserver.assertComplete();
+        stream.onNext("detach");
+        attachObserver.assertNotComplete();
+        attachObserver.assertValues("attach", "create", "createView", "start", "resume",
+                "pause", "stop", "destroyView", "destroy");
+        destroyObserver.assertNotComplete();
+        destroyObserver.assertValues("destroy");
     }
 
     // Easier than making everyone create their own shadows

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle2/Functions.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle2/Functions.java
@@ -14,11 +14,9 @@
 
 package com.trello.rxlifecycle2;
 
-import io.reactivex.Completable;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.functions.Predicate;
-import java.util.concurrent.CancellationException;
 
 final class Functions {
 
@@ -39,13 +37,6 @@ final class Functions {
         @Override
         public boolean test(Boolean shouldComplete) throws Exception {
             return shouldComplete;
-        }
-    };
-
-    static final Function<Object, Completable> CANCEL_COMPLETABLE = new Function<Object, Completable>() {
-        @Override
-        public Completable apply(Object ignore) throws Exception {
-            return Completable.error(new CancellationException());
         }
     };
 

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle2/LifecycleTransformer.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle2/LifecycleTransformer.java
@@ -14,7 +14,12 @@
 
 package com.trello.rxlifecycle2;
 
-import io.reactivex.BackpressureStrategy;
+import com.trello.rxlifecycle2.internal.CompletableDisposeWhen;
+import com.trello.rxlifecycle2.internal.FlowableCancelWhen;
+import com.trello.rxlifecycle2.internal.MaybeDisposeWhen;
+import com.trello.rxlifecycle2.internal.ObservableDisposeWhen;
+import com.trello.rxlifecycle2.internal.SingleDisposeWhen;
+
 import io.reactivex.Completable;
 import io.reactivex.CompletableSource;
 import io.reactivex.CompletableTransformer;
@@ -54,27 +59,27 @@ public final class LifecycleTransformer<T> implements ObservableTransformer<T, T
 
     @Override
     public ObservableSource<T> apply(Observable<T> upstream) {
-        return upstream.takeUntil(observable);
+        return new ObservableDisposeWhen<>(upstream, observable);
     }
 
     @Override
     public Publisher<T> apply(Flowable<T> upstream) {
-        return upstream.takeUntil(observable.toFlowable(BackpressureStrategy.LATEST));
+        return new FlowableCancelWhen<>(upstream, observable);
     }
 
     @Override
     public SingleSource<T> apply(Single<T> upstream) {
-        return upstream.takeUntil(observable.firstOrError());
+        return new SingleDisposeWhen<>(upstream, observable);
     }
 
     @Override
     public MaybeSource<T> apply(Maybe<T> upstream) {
-        return upstream.takeUntil(observable.firstElement());
+        return new MaybeDisposeWhen<>(upstream, observable);
     }
 
     @Override
     public CompletableSource apply(Completable upstream) {
-        return Completable.ambArray(upstream, observable.flatMapCompletable(Functions.CANCEL_COMPLETABLE));
+        return new CompletableDisposeWhen(upstream, observable);
     }
 
     @Override

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle2/internal/CompletableDisposeWhen.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle2/internal/CompletableDisposeWhen.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.trello.rxlifecycle2.internal;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import io.reactivex.Completable;
+import io.reactivex.CompletableObserver;
+import io.reactivex.CompletableSource;
+import io.reactivex.ObservableSource;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.ArrayCompositeDisposable;
+
+@ParametersAreNonnullByDefault
+public final class CompletableDisposeWhen extends Completable {
+    private final CompletableSource upstream;
+    private final ObservableSource<?> observable;
+
+    public CompletableDisposeWhen(CompletableSource upstream, ObservableSource<?> observable) {
+        this.upstream = upstream;
+        this.observable = observable;
+    }
+
+    @Override
+    protected void subscribeActual(final CompletableObserver downstream) {
+        final ArrayCompositeDisposable frc = new ArrayCompositeDisposable(2);
+
+        downstream.onSubscribe(frc);
+
+        observable.subscribe(new Observer<Object>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                frc.setResource(0, d);
+            }
+
+            @Override
+            public void onNext(Object o) {
+                frc.dispose();
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                frc.dispose();
+                downstream.onError(t);
+            }
+
+            @Override
+            public void onComplete() {
+                frc.dispose();
+            }
+        });
+
+        upstream.subscribe(new CompletableObserver() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                frc.setResource(1, d);
+            }
+
+            @Override
+            public void onComplete() {
+                frc.dispose();
+                downstream.onComplete();
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                frc.dispose();
+                downstream.onError(t);
+            }
+        });
+    }
+}

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle2/internal/FlowableCancelWhen.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle2/internal/FlowableCancelWhen.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.trello.rxlifecycle2.internal;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import io.reactivex.Flowable;
+import io.reactivex.ObservableSource;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.internal.util.AtomicThrowable;
+import io.reactivex.internal.util.HalfSerializer;
+
+@ParametersAreNonnullByDefault
+public final class FlowableCancelWhen<T> extends Flowable<T> {
+    private final Publisher<T> upstream;
+    private final ObservableSource<?> observable;
+
+    public FlowableCancelWhen(Publisher<T> upstream, ObservableSource<?> observable) {
+        this.upstream = upstream;
+        this.observable = observable;
+    }
+
+    @Override
+    protected void subscribeActual(final Subscriber<? super T> downstream) {
+        final MainSubscriber mainSubscriber = new MainSubscriber(downstream);
+
+        downstream.onSubscribe(mainSubscriber);
+
+        observable.subscribe(mainSubscriber.other);
+        upstream.subscribe(mainSubscriber);
+    }
+
+    final class MainSubscriber extends AtomicInteger implements Subscriber<T>, Subscription {
+        private static final long serialVersionUID = 919611990130321642L;
+        final Subscriber<? super T> actual;
+        final OtherObserver other;
+        final AtomicReference<Subscription> s;
+        final AtomicLong requested;
+        final AtomicThrowable error;
+
+        MainSubscriber(Subscriber<? super T> actual) {
+            this.actual = actual;
+            this.requested = new AtomicLong();
+            this.s = new AtomicReference<>();
+            this.other = new OtherObserver();
+            this.error = new AtomicThrowable();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            SubscriptionHelper.deferredSetOnce(this.s, requested, s);
+        }
+
+        @Override
+        public void onNext(T o) {
+            HalfSerializer.onNext(actual, o, this, error);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            DisposableHelper.dispose(other);
+            HalfSerializer.onError(actual, t, this, error);
+        }
+
+        @Override
+        public void onComplete() {
+            DisposableHelper.dispose(other);
+            HalfSerializer.onComplete(actual, this, error);
+        }
+
+        @Override
+        public void request(long n) {
+            SubscriptionHelper.deferredRequest(s, requested, n);
+        }
+
+        @Override
+        public void cancel() {
+            SubscriptionHelper.cancel(s);
+            DisposableHelper.dispose(other);
+        }
+
+        final class OtherObserver extends AtomicReference<Disposable> implements Observer<Object> {
+            private static final long serialVersionUID = -6684536082750051972L;
+
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.setOnce(this, d);
+            }
+
+            @Override
+            public void onNext(Object o) {
+                DisposableHelper.dispose(this);
+                SubscriptionHelper.cancel(s);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                DisposableHelper.dispose(this);
+                SubscriptionHelper.cancel(s);
+                HalfSerializer.onError(actual, t, MainSubscriber.this, error);
+            }
+
+            @Override
+            public void onComplete() {
+                DisposableHelper.dispose(this);
+                SubscriptionHelper.cancel(s);
+            }
+        }
+    }
+}

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle2/internal/MaybeDisposeWhen.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle2/internal/MaybeDisposeWhen.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.trello.rxlifecycle2.internal;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
+import io.reactivex.MaybeSource;
+import io.reactivex.ObservableSource;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.ArrayCompositeDisposable;
+
+@ParametersAreNonnullByDefault
+public final class MaybeDisposeWhen<T> extends Maybe<T> {
+    private final MaybeSource<T> upstream;
+    private final ObservableSource<?> observable;
+
+    public MaybeDisposeWhen(MaybeSource<T> upstream, ObservableSource<?> observable) {
+        this.upstream = upstream;
+        this.observable = observable;
+    }
+
+    @Override
+    protected void subscribeActual(final MaybeObserver<? super T> downstream) {
+        final ArrayCompositeDisposable frc = new ArrayCompositeDisposable(2);
+
+        downstream.onSubscribe(frc);
+
+        observable.subscribe(new Observer<Object>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                frc.setResource(0, d);
+            }
+
+            @Override
+            public void onNext(Object o) {
+                frc.dispose();
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                frc.dispose();
+                downstream.onError(t);
+            }
+
+            @Override
+            public void onComplete() {
+                frc.dispose();
+            }
+        });
+
+        upstream.subscribe(new MaybeObserver<T>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                frc.setResource(1, d);
+            }
+
+            @Override
+            public void onSuccess(T o) {
+                frc.dispose();
+                downstream.onSuccess(o);
+            }
+
+            @Override
+            public void onComplete() {
+                frc.dispose();
+                downstream.onComplete();
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                frc.dispose();
+                downstream.onError(t);
+            }
+        });
+    }
+}

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle2/internal/ObservableDisposeWhen.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle2/internal/ObservableDisposeWhen.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.trello.rxlifecycle2.internal;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.ArrayCompositeDisposable;
+
+@ParametersAreNonnullByDefault
+public final class ObservableDisposeWhen<T> extends Observable<T> {
+    private final ObservableSource<T> upstream;
+    private final ObservableSource<?> observable;
+
+    public ObservableDisposeWhen(ObservableSource<T> upstream, ObservableSource<?> observable) {
+        this.upstream = upstream;
+        this.observable = observable;
+    }
+
+    @Override
+    protected void subscribeActual(final Observer<? super T> downstream) {
+        final ArrayCompositeDisposable frc = new ArrayCompositeDisposable(2);
+
+        downstream.onSubscribe(frc);
+
+        observable.subscribe(new Observer<Object>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                frc.setResource(0, d);
+            }
+
+            @Override
+            public void onNext(Object o) {
+                frc.dispose();
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                frc.dispose();
+                downstream.onError(t);
+            }
+
+            @Override
+            public void onComplete() {
+                frc.dispose();
+            }
+        });
+
+        upstream.subscribe(new Observer<T>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                frc.setResource(1, d);
+            }
+
+            @Override
+            public void onNext(T o) {
+                downstream.onNext(o);
+            }
+
+            @Override
+            public void onComplete() {
+                frc.dispose();
+                downstream.onComplete();
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                frc.dispose();
+                downstream.onError(t);
+            }
+        });
+    }
+}

--- a/rxlifecycle/src/main/java/com/trello/rxlifecycle2/internal/SingleDisposeWhen.java
+++ b/rxlifecycle/src/main/java/com/trello/rxlifecycle2/internal/SingleDisposeWhen.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.trello.rxlifecycle2.internal;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import io.reactivex.ObservableSource;
+import io.reactivex.Observer;
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
+import io.reactivex.SingleSource;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.ArrayCompositeDisposable;
+
+@ParametersAreNonnullByDefault
+public final class SingleDisposeWhen<T> extends Single<T> {
+    private final SingleSource<T> upstream;
+    private final ObservableSource<?> observable;
+
+    public SingleDisposeWhen(SingleSource<T> upstream, ObservableSource<?> observable) {
+        this.upstream = upstream;
+        this.observable = observable;
+    }
+
+    @Override
+    protected void subscribeActual(final SingleObserver<? super T> downstream) {
+        final ArrayCompositeDisposable frc = new ArrayCompositeDisposable(2);
+
+        downstream.onSubscribe(frc);
+
+        observable.subscribe(new Observer<Object>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                frc.setResource(0, d);
+            }
+
+            @Override
+            public void onNext(Object o) {
+                frc.dispose();
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                frc.dispose();
+                downstream.onError(t);
+            }
+
+            @Override
+            public void onComplete() {
+                frc.dispose();
+            }
+        });
+
+        upstream.subscribe(new SingleObserver<T>() {
+            @Override
+            public void onSubscribe(Disposable d) {
+                frc.setResource(1, d);
+            }
+
+            @Override
+            public void onSuccess(T o) {
+                frc.dispose();
+                downstream.onSuccess(o);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                frc.dispose();
+                downstream.onError(t);
+            }
+        });
+    }
+}

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/OutsideLifecycleExceptionTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/OutsideLifecycleExceptionTest.java
@@ -32,12 +32,14 @@ public class OutsideLifecycleExceptionTest {
             .compose(RxLifecycle.<String, String>bind(lifecycle, CORRESPONDING_EVENTS))
             .test();
 
-        // Event is out of lifecycle, but this just results in completing the stream
+        // Event is out of lifecycle, this will result in dispose the stream
         lifecycle.onNext("destroy");
         stream.onNext("1");
 
         testObserver.assertNoValues();
-        testObserver.assertComplete();
+        testObserver.assertNotComplete();
+        // We will not emit OutsideLifecycleException to downstream.
+        testObserver.assertNoErrors();
     }
 
     @Test

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/RxLifecycleTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/RxLifecycleTest.java
@@ -37,7 +37,7 @@ public class RxLifecycleTest {
         TestObserver<Object> testObserver = observable.compose(RxLifecycle.bind(lifecycle)).test();
         testObserver.assertNotComplete();
         lifecycle.onNext(new Object());
-        testObserver.assertComplete();
+        testObserver.assertNotComplete();
     }
 
     @Test
@@ -47,7 +47,7 @@ public class RxLifecycleTest {
         TestObserver<Object> testObserver = observable.compose(RxLifecycle.bind(lifecycle)).test();
         testObserver.assertNotComplete();
         lifecycle.onNext("");
-        testObserver.assertComplete();
+        testObserver.assertNotComplete();
     }
 
     // Null checks

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilCorrespondingEventTransformerCompletableTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilCorrespondingEventTransformerCompletableTest.java
@@ -21,8 +21,6 @@ import io.reactivex.subjects.PublishSubject;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.CancellationException;
-
 public class UntilCorrespondingEventTransformerCompletableTest {
 
     PublishSubject<Object> subject;
@@ -78,7 +76,7 @@ public class UntilCorrespondingEventTransformerCompletableTest {
         lifecycle.onNext("create");
         lifecycle.onNext("destroy");
         subject.onComplete();
-        testObserver.assertError(CancellationException.class);
+        testObserver.assertNotComplete();
     }
 
     private static final Function<String, String> CORRESPONDING_EVENTS = new Function<String, String>() {

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilCorrespondingEventTransformerFlowableTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilCorrespondingEventTransformerFlowableTest.java
@@ -85,7 +85,7 @@ public class UntilCorrespondingEventTransformerFlowableTest {
         stream.onNext("2");
 
         testSubscriber.assertValues("1");
-        testSubscriber.assertComplete();
+        testSubscriber.assertNotComplete();
     }
 
     private static final Function<String, String> CORRESPONDING_EVENTS = new Function<String, String>() {

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilCorrespondingEventTransformerMaybeTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilCorrespondingEventTransformerMaybeTest.java
@@ -80,7 +80,7 @@ public class UntilCorrespondingEventTransformerMaybeTest {
         lifecycle.onNext("destroy");
         subject.onNext("1");
         testObserver.assertNoValues();
-        testObserver.assertComplete();
+        testObserver.assertNotComplete();
     }
 
     private static final Function<String, String> CORRESPONDING_EVENTS = new Function<String, String>() {

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilCorrespondingEventTransformerObservableTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilCorrespondingEventTransformerObservableTest.java
@@ -84,7 +84,7 @@ public class UntilCorrespondingEventTransformerObservableTest {
         stream.onNext("2");
 
         testObserver.assertValues("1");
-        testObserver.assertComplete();
+        testObserver.assertNotComplete();
     }
 
     private static final Function<String, String> CORRESPONDING_EVENTS = new Function<String, String>() {

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilCorrespondingEventTransformerSingleTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilCorrespondingEventTransformerSingleTest.java
@@ -22,7 +22,6 @@ import io.reactivex.subjects.PublishSubject;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 
 public class UntilCorrespondingEventTransformerSingleTest {
@@ -94,7 +93,7 @@ public class UntilCorrespondingEventTransformerSingleTest {
         lifecycle.onNext("destroy");
         testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
         testObserver.assertNoValues();
-        testObserver.assertError(CancellationException.class);
+        testObserver.assertNotComplete();
     }
 
     private static final Function<String, String> CORRESPONDING_EVENTS = new Function<String, String>() {

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilEventTransformerCompletableTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilEventTransformerCompletableTest.java
@@ -20,8 +20,6 @@ import io.reactivex.subjects.PublishSubject;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.CancellationException;
-
 public class UntilEventTransformerCompletableTest {
 
     PublishSubject<Object> subject;
@@ -65,7 +63,7 @@ public class UntilEventTransformerCompletableTest {
         lifecycle.onNext("keep going");
         lifecycle.onNext("stop");
         subject.onComplete();
-        testObserver.assertError(CancellationException.class);
+        testObserver.assertNotComplete();
     }
 
 }

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilEventTransformerFlowableTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilEventTransformerFlowableTest.java
@@ -70,7 +70,7 @@ public class UntilEventTransformerFlowableTest {
         stream.onNext("3");
 
         testSubscriber.assertValues("1", "2");
-        testSubscriber.assertComplete();
+        testSubscriber.assertNotComplete();
     }
 
 }

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilEventTransformerMaybeTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilEventTransformerMaybeTest.java
@@ -67,7 +67,7 @@ public class UntilEventTransformerMaybeTest {
 
         subject.onNext("1");
         testObserver.assertNoValues();
-        testObserver.assertComplete();
+        testObserver.assertNotComplete();
     }
 
 }

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilEventTransformerObservableTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilEventTransformerObservableTest.java
@@ -69,7 +69,7 @@ public class UntilEventTransformerObservableTest {
         stream.onNext("3");
 
         testObserver.assertValues("1", "2");
-        testObserver.assertComplete();
+        testObserver.assertNotComplete();
     }
 
 }

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilEventTransformerSingleTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilEventTransformerSingleTest.java
@@ -21,7 +21,6 @@ import io.reactivex.subjects.PublishSubject;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 
 public class UntilEventTransformerSingleTest {
@@ -79,7 +78,7 @@ public class UntilEventTransformerSingleTest {
         testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
         testObserver.assertNoValues();
-        testObserver.assertError(CancellationException.class);
+        testObserver.assertNotComplete();
     }
 
 }

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilLifecycleTransformerCompletableTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilLifecycleTransformerCompletableTest.java
@@ -20,8 +20,6 @@ import io.reactivex.subjects.PublishSubject;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.CancellationException;
-
 public class UntilLifecycleTransformerCompletableTest {
 
     PublishSubject<Object> subject;
@@ -55,6 +53,6 @@ public class UntilLifecycleTransformerCompletableTest {
         lifecycle.onNext("stop");
         subject.onComplete();
 
-        testObserver.assertError(CancellationException.class);
+        testObserver.assertNotComplete();
     }
 }

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilLifecycleTransformerFlowableTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilLifecycleTransformerFlowableTest.java
@@ -54,6 +54,6 @@ public class UntilLifecycleTransformerFlowableTest {
         stream.onNext("2");
 
         testSubscriber.assertValues("1");
-        testSubscriber.assertComplete();
+        testSubscriber.assertNotComplete();
     }
 }

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilLifecycleTransformerMaybeTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilLifecycleTransformerMaybeTest.java
@@ -54,6 +54,6 @@ public class UntilLifecycleTransformerMaybeTest {
         stream.onNext("1");
 
         testObserver.assertNoValues();
-        testObserver.assertComplete();
+        testObserver.assertNotComplete();
     }
 }

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilLifecycleTransformerObservableTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilLifecycleTransformerObservableTest.java
@@ -53,6 +53,6 @@ public class UntilLifecycleTransformerObservableTest {
         stream.onNext("2");
 
         testObserver.assertValues("1");
-        testObserver.assertComplete();
+        testObserver.assertNotComplete();
     }
 }

--- a/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilLifecycleTransformerSingleTest.java
+++ b/rxlifecycle/src/test/java/com/trello/rxlifecycle2/UntilLifecycleTransformerSingleTest.java
@@ -21,7 +21,6 @@ import io.reactivex.subjects.PublishSubject;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 
 public class UntilLifecycleTransformerSingleTest {
@@ -63,6 +62,6 @@ public class UntilLifecycleTransformerSingleTest {
         testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
         testObserver.assertNoValues();
-        testObserver.assertError(CancellationException.class);
+        testObserver.assertNotComplete();
     }
 }


### PR DESCRIPTION
This PR add custom operator `DisposeWhen` to cancel a subscription when the lifecycle observable emits an item. Unlike the `TakeUtil` operator, `DisposeWhen` will not emit any event (onComplete、onError ...) to the downstream observer if the subscription has been cancel.

All of the tests have been updated. And all ot them have passed on my computer.
  
  
  