### PR TITLE
Support LayoutId constructors for AppCompatActivity and (AndroidX)Fragment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,9 @@ ext {
     compileSdkVersion = 28
     targetSdkVersion = compileSdkVersion
 
-    supportLibVersion = '1.0.0'
-    lifecycleVersion = '1.1.1'
-    lifecycleRuntimeVersion = '1.1.1'
+    supportLibVersion = '1.1.0'
+    lifecycleVersion = '2.1.0'
+    lifecycleRuntimeVersion = '2.1.0'
 
     sourceCompatibilityVersion = JavaVersion.VERSION_1_7
     targetCompatibilityVersion = JavaVersion.VERSION_1_7

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle3/components/support/RxAppCompatActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle3/components/support/RxAppCompatActivity.java
@@ -16,23 +16,35 @@ package com.trello.rxlifecycle3.components.support;
 
 import android.os.Bundle;
 
+import androidx.annotation.CallSuper;
+import androidx.annotation.CheckResult;
+import androidx.annotation.ContentView;
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
 import com.trello.rxlifecycle3.LifecycleProvider;
 import com.trello.rxlifecycle3.LifecycleTransformer;
 import com.trello.rxlifecycle3.RxLifecycle;
 import com.trello.rxlifecycle3.android.ActivityEvent;
 import com.trello.rxlifecycle3.android.RxLifecycleAndroid;
 
-import androidx.annotation.CallSuper;
-import androidx.annotation.CheckResult;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
 import io.reactivex.Observable;
 import io.reactivex.subjects.BehaviorSubject;
 
 public abstract class RxAppCompatActivity extends AppCompatActivity implements LifecycleProvider<ActivityEvent> {
 
     private final BehaviorSubject<ActivityEvent> lifecycleSubject = BehaviorSubject.create();
+
+    public RxAppCompatActivity() {
+        super();
+    }
+
+    @ContentView
+    public RxAppCompatActivity(@LayoutRes int contentLayoutId) {
+        super(contentLayoutId);
+    }
 
     @Override
     @NonNull

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle3/components/support/RxFragment.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle3/components/support/RxFragment.java
@@ -17,22 +17,34 @@ package com.trello.rxlifecycle3.components.support;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.annotation.CheckResult;
+import androidx.annotation.ContentView;
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
 import com.trello.rxlifecycle3.LifecycleProvider;
 import com.trello.rxlifecycle3.LifecycleTransformer;
 import com.trello.rxlifecycle3.RxLifecycle;
 import com.trello.rxlifecycle3.android.FragmentEvent;
 import com.trello.rxlifecycle3.android.RxLifecycleAndroid;
 
-import androidx.annotation.CheckResult;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
 import io.reactivex.Observable;
 import io.reactivex.subjects.BehaviorSubject;
 
 public abstract class RxFragment extends Fragment implements LifecycleProvider<FragmentEvent> {
 
     private final BehaviorSubject<FragmentEvent> lifecycleSubject = BehaviorSubject.create();
+
+    public RxFragment() {
+        super();
+    }
+
+    @ContentView
+    public RxFragment(@LayoutRes int contentLayoutId) {
+        super(contentLayoutId);
+    }
 
     @Override
     @NonNull

--- a/rxlifecycle-components/src/main/java/com/trello/rxlifecycle3/components/support/RxFragmentActivity.java
+++ b/rxlifecycle-components/src/main/java/com/trello/rxlifecycle3/components/support/RxFragmentActivity.java
@@ -16,23 +16,35 @@ package com.trello.rxlifecycle3.components.support;
 
 import android.os.Bundle;
 
+import androidx.annotation.CallSuper;
+import androidx.annotation.CheckResult;
+import androidx.annotation.ContentView;
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentActivity;
+
 import com.trello.rxlifecycle3.LifecycleProvider;
 import com.trello.rxlifecycle3.LifecycleTransformer;
 import com.trello.rxlifecycle3.RxLifecycle;
 import com.trello.rxlifecycle3.android.ActivityEvent;
 import com.trello.rxlifecycle3.android.RxLifecycleAndroid;
 
-import androidx.annotation.CallSuper;
-import androidx.annotation.CheckResult;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.FragmentActivity;
 import io.reactivex.Observable;
 import io.reactivex.subjects.BehaviorSubject;
 
 public abstract class RxFragmentActivity extends FragmentActivity implements LifecycleProvider<ActivityEvent> {
 
     private final BehaviorSubject<ActivityEvent> lifecycleSubject = BehaviorSubject.create();
+
+    public RxFragmentActivity() {
+        super();
+    }
+
+    @ContentView
+    public RxFragmentActivity(@LayoutRes int contentLayoutId) {
+        super(contentLayoutId);
+    }
 
     @Override
     @NonNull


### PR DESCRIPTION
Latest AndroidX AppCompat library supports LayoutId constructor.

https://developer.android.com/jetpack/androidx/releases/appcompat#1.1.0

I want to RxLifecycle's RxAppCompatActivity ,etc... supports that constructor.