### PR TITLE
Corrected package name in rxlifecycle-android-lifecycle-kotlin

### DIFF
--- a/rxlifecycle-android-lifecycle-kotlin/src/main/AndroidManifest.xml
+++ b/rxlifecycle-android-lifecycle-kotlin/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="me.tatarka.rxlifecycle_android_lifecycle_kotlin" />
+<manifest package="com.trello.rxlifecycle4.android.lifecycle.kotlin" />


### PR DESCRIPTION
Not sure how this ended up being so randomly weird, but it was not following
conventions. In particular, it should be namespaced to the version of rxlifecycle
so that we're not having any collisions between different major versions.

Fixes #329 