### PR TITLE
Namespace Kotlin module names

### DIFF
--- a/rxlifecycle-android-lifecycle-kotlin/build.gradle
+++ b/rxlifecycle-android-lifecycle-kotlin/build.gradle
@@ -8,6 +8,10 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
     }
+
+    kotlinOptions {
+        freeCompilerArgs += ["-module-name", "rxlifecycle-android-lifecycle-kotlin-4"]
+    }
 }
 
 repositories {

--- a/rxlifecycle-kotlin/build.gradle
+++ b/rxlifecycle-kotlin/build.gradle
@@ -8,6 +8,10 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
     }
+
+    kotlinOptions {
+        freeCompilerArgs += ["-module-name", "rxlifecycle-kotlin-4"]
+    }
 }
 
 repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
-include ':rxlifecycle', ':rxlifecycle-android-lifecycle-kotlin'
+include ':rxlifecycle'
 include ':rxlifecycle-android'
 include ':rxlifecycle-android-lifecycle'
+include ':rxlifecycle-android-lifecycle-kotlin'
 include ':rxlifecycle-components'
 include ':rxlifecycle-components-preference'
 include ':rxlifecycle-kotlin'


### PR DESCRIPTION
Otherwise you can't use different major versions of RxLifecycle side-by-side
due to the generated .kotlin_module file.

Fixes #329